### PR TITLE
True false

### DIFF
--- a/cc/ccom/trees.c
+++ b/cc/ccom/trees.c
@@ -2128,7 +2128,7 @@ fixbranch(P1ND *p, int label)
  * Write out logical expressions as branches.
  */
 static void
-andorbr(P1ND *p, int true, int false)
+andorbr(P1ND *p, int _true, int _false)
 {
 	P1ND *q;
 	int o, lab;
@@ -2171,20 +2171,20 @@ andorbr(P1ND *p, int true, int false)
 	case LT:
 	case GE:
 	case GT:
-calc:		if (true < 0) {
+calc:		if (_true < 0) {
 			p->n_op = p1negrel[p->n_op - EQ];
 			p->n_ap = attr_add(p->n_ap,
 			    attr_new(ATTR_FP_SWAPPED, 3));
 			p->n_ap->aa[0].iarg = 1;
-			true = false;
-			false = -1;
+			_true = _false;
+			_false = -1;
 		}
 
 		rmcops(p->n_left);
 		rmcops(p->n_right);
-		fixbranch(p, true);
-		if (false >= 0)
-			branch(false);
+		fixbranch(p, _true);
+		if (_false >= 0)
+			branch(_false);
 		break;
 
 	case ULE:
@@ -2198,9 +2198,9 @@ calc:		if (true < 0) {
 	case ULT:
 		/* Already true/false by definition */
 		if (nncon(p->n_right) && glval(p->n_right) == 0) {
-			if (true < 0) {
+			if (_true < 0) {
 				o = o == ULT ? UGE : ULT;
-				true = false;
+				_true = _false;
 			}
 			rmcops(p->n_left);
 			ecode(p->n_left);
@@ -2208,45 +2208,45 @@ calc:		if (true < 0) {
 			ecode(p->n_right);
 			p1nfree(p);
 			if (o == UGE) /* true */
-				branch(true);
+				branch(_true);
 			break;
 		}
 		goto calc;
 
 	case ANDAND:
-		lab = false<0 ? getlab() : false ;
+		lab = _false<0 ? getlab() : _false ;
 		andorbr(p->n_left, -1, lab);
 		comops(p->n_right);
-		andorbr(p->n_right, true, false);
-		if (false < 0)
+		andorbr(p->n_right, _true, _false);
+		if (_false < 0)
 			plabel( lab);
 		p1nfree(p);
 		break;
 
 	case OROR:
-		lab = true<0 ? getlab() : true;
+		lab = _true<0 ? getlab() : _true;
 		andorbr(p->n_left, lab, -1);
 		comops(p->n_right);
-		andorbr(p->n_right, true, false);
-		if (true < 0)
+		andorbr(p->n_right, _true, _false);
+		if (_true < 0)
 			plabel( lab);
 		p1nfree(p);
 		break;
 
 	case NOT:
-		andorbr(p->n_left, false, true);
+		andorbr(p->n_left, _false, _true);
 		p1nfree(p);
 		break;
 
 	default:
 		rmcops(p);
-		if (true >= 0)
-			fixbranch(p, true);
-		if (false >= 0) {
-			if (true >= 0)
-				branch(false);
+		if (_true >= 0)
+			fixbranch(p, _true);
+		if (_false >= 0) {
+			if (_true >= 0)
+				branch(_false);
 			else
-				fixbranch(buildtree(EQ, p, bcon(0)), false);
+				fixbranch(buildtree(EQ, p, bcon(0)), _false);
 		}
 	}
 }

--- a/cc/cxxcom/trees.c
+++ b/cc/cxxcom/trees.c
@@ -2024,7 +2024,7 @@ fixbranch(NODE *p, int label)
  * Write out logical expressions as branches.
  */
 static void
-andorbr(NODE *p, int true, int false)
+andorbr(NODE *p, int _true, int _false)
 {
 	NODE *q;
 	int o, lab;
@@ -2067,17 +2067,17 @@ andorbr(NODE *p, int true, int false)
 	case LT:
 	case GE:
 	case GT:
-calc:		if (true < 0) {
+calc:		if (_true < 0) {
 			p->n_op = negrel[p->n_op - EQ];
-			true = false;
-			false = -1;
+			_true = _false;
+			_false = -1;
 		}
 
 		rmcops(p->n_left);
 		rmcops(p->n_right);
-		fixbranch(p, true);
-		if (false >= 0)
-			branch(false);
+		fixbranch(p, _true);
+		if (_false >= 0)
+			branch(_false);
 		break;
 
 	case ULE:
@@ -2091,9 +2091,9 @@ calc:		if (true < 0) {
 	case ULT:
 		/* Already true/false by definition */
 		if (nncon(p->n_right) && glval(p->n_right) == 0) {
-			if (true < 0) {
+			if (_true < 0) {
 				o = o == ULT ? UGE : ULT;
-				true = false;
+				_true = _false;
 			}
 			rmcops(p->n_left);
 			ecode(p->n_left);
@@ -2101,45 +2101,45 @@ calc:		if (true < 0) {
 			ecode(p->n_right);
 			nfree(p);
 			if (o == UGE) /* true */
-				branch(true);
+				branch(_true);
 			break;
 		}
 		goto calc;
 
 	case ANDAND:
-		lab = false<0 ? getlab() : false ;
+		lab = _false<0 ? getlab() : _false ;
 		andorbr(p->n_left, -1, lab);
 		comops(p->n_right);
-		andorbr(p->n_right, true, false);
-		if (false < 0)
+		andorbr(p->n_right, _true, _false);
+		if (_false < 0)
 			plabel( lab);
 		nfree(p);
 		break;
 
 	case OROR:
-		lab = true<0 ? getlab() : true;
+		lab = _true<0 ? getlab() : _true;
 		andorbr(p->n_left, lab, -1);
 		comops(p->n_right);
-		andorbr(p->n_right, true, false);
-		if (true < 0)
+		andorbr(p->n_right, _true, _false);
+		if (_true < 0)
 			plabel( lab);
 		nfree(p);
 		break;
 
 	case NOT:
-		andorbr(p->n_left, false, true);
+		andorbr(p->n_left, _false, _true);
 		nfree(p);
 		break;
 
 	default:
 		rmcops(p);
-		if (true >= 0)
-			fixbranch(p, true);
-		if (false >= 0) {
-			if (true >= 0)
-				branch(false);
+		if (_true >= 0)
+			fixbranch(p, _true);
+		if (_false >= 0) {
+			if (_true >= 0)
+				branch(_false);
 			else
-				fixbranch(buildtree(EQ, p, bcon(0)), false);
+				fixbranch(buildtree(EQ, p, bcon(0)), _false);
 		}
 	}
 }


### PR DESCRIPTION
At least with gcc 15.1.1 (Archlinux) (C99) I get errors around `true` and `false`
being used as names for variables:

```
./trees.c:2131:22: error: expected ‘;’, ‘,’ or ‘)’ before ‘true’
 2131 | andorbr(P1ND *p, int true, int false)
      |                      ^~~~
./trees.c: In function ‘rmcops’:
./trees.c:2316:17: error: implicit declaration of function ‘andorbr’ [-Wimplicit-function-declaration]
 2316 |                 andorbr(p->n_left, -1, lbl = getlab());
      |                 ^~~~~~~
./trees.c: At top level:
./trees.c:2111:1: warning: ‘fixbranch’ defined but not used [-Wunused-function]
 2111 | fixbranch(P1ND *p, int label)
      | ^~~~~~~~~
```

_true and _false as replacement variables might also be not good. :-)
