### PR TITLE
Fix segfault in prototype/parameter checks

### DIFF
--- a/cc/ccom/params.c
+++ b/cc/ccom/params.c
@@ -374,10 +374,10 @@ pr_rptr(void)
 {
 	uintptr_t w, w2;
 
-	w = w2 = pr_rd();
+	w = w2 = (unsigned)pr_rd();
 	if (sizeof(uintptr_t) > sizeof(int)) {
 		w &= 0xffffffffL;
-		w2 = pr_rd() << 16;
+		w2 = (unsigned)pr_rd() << 16;
 		w2 = (w2 << 16) | w;
 	}
 	return w2;


### PR DESCRIPTION
Return value of pr_rd() was cast from int->uintptr_t with a sign-extend, which on 64-bit machines led to addresses being filled in with 1s, causing segfaults. Fixed by casting first to unsigned so it zero-extends.


For some reason I only experienced this bug on Aarch64, when referring to forward-declared structs as parameters, such as `FILE*` parameters.