### PR TITLE
Convert C++ style comments (//) to C89-compatible /* */ style

### DIFF
--- a/arch/aarch64/local2.c
+++ b/arch/aarch64/local2.c
@@ -45,7 +45,7 @@ In a 64-bit context,registers are specified by using x0-x30 in A64 instruction s
 */
 char *rnames[] = {
 	"x0", "x1", "x2", "x3","x4","x5", "x6", "x7",
-	"x8", "x9", "x10","x11","x12","x13","x14", 
+	"x8", "x9", "x10","x11","x12","x13","x14",
 	"x15", "x16","x17","x18","x19","x20", "x21",
 	"x22","x23","x24","x25","x26","x27","x28",
 	"x29","x30","sp",
@@ -95,7 +95,7 @@ encode_constant(int constant, int *values)
 }
 
 /*
- * Use W registers to load value in 32-bit context 
+ * Use W registers to load value in 32-bit context
  */
 static void
 load_constant_into_reg(int reg, int v)
@@ -162,7 +162,7 @@ prologue(struct interpass_prolog *ipp)
         printf("%s:\n", exname(ipp->ipp_name));
         addto = offcalc(ipp);
         if (addto < 64){
-		addto = 64;       
+		addto = 64;
         }
         if((addto % 16)){
                 addto = addto + (16 - (addto % 16));
@@ -501,7 +501,7 @@ emul(NODE *p)
 	else if (p->n_op == RS && p->n_type == LONGLONG) ch = "ashrdi3";
 	else if (p->n_op == RS && p->n_type == LONG) ch = "ashrsi3";
 	else if (p->n_op == RS && p->n_type == INT) ch = "ashrsi3";
-	
+
 	else if (p->n_op == MUL && p->n_type == LONGLONG) ch = "muldi3";
 	else if (p->n_op == MUL && p->n_type == LONG) ch = "mulsi3";
 	else if (p->n_op == MUL && p->n_type == INT) ch = "mulsi3";
@@ -692,7 +692,7 @@ conput(FILE *fp, NODE *p)
 				s = exname(p->n_name);
 #else
 			s = p->n_name;
-#endif		
+#endif
 			if (*s != '\0') {
 				fprintf(fp, "%s", s);
 				if (val > 0)
@@ -773,7 +773,7 @@ adrput(FILE *io, NODE *p)
 			/* addressable value of the constant */
 			conput(io, p);
 			return;
-	
+
 		case REG:
 			switch (p->n_type) {
 				case CHAR:
@@ -943,7 +943,7 @@ prtaddr(NODE *p, void *arg)
 				    lab, l->n_name, getlval(l));
 			 else
                                 printf(PRTLAB ":\n\t.dword %s\n",
-                                    lab, l->n_name);	
+                                    lab, l->n_name);
 		}
 		el = tmpalloc(sizeof(struct addrsymb));
 		el->num = getlval(l);
@@ -1178,7 +1178,7 @@ static int fset = DEFAULT_FEATURES;
 void
 mflags(char *str)
 {
-	//Handling needs to be done for ARMv8
+	/* Handling needs to be done for ARMv8 */
 }
 int
 features(int mask)

--- a/arch/aarch64/macdefs.h
+++ b/arch/aarch64/macdefs.h
@@ -130,7 +130,7 @@ typedef long long OFFSZ;
 #define R28	28
 #define R29	29
 #define R30	30
-#define R31	31   //SP register
+#define R31	31   /* SP register */
 
 #define FP	R29
 #define IP	R16
@@ -138,7 +138,7 @@ typedef long long OFFSZ;
 #define LR	R30
 
 #define NUMCLASS 3
-#define	MAXREGS  34	
+#define	MAXREGS  34
 
 #define RSTATUS \
 	SAREG|TEMPREG, SAREG|TEMPREG, SAREG|TEMPREG, SAREG|TEMPREG,	\

--- a/arch/amd64/local2.c
+++ b/arch/amd64/local2.c
@@ -144,7 +144,7 @@ prologue(struct interpass_prolog *ipp)
 	printf("%s:\n", ipp->ipp_name);
 #endif
 	/*
-	 * We here know what register to save and how much to 
+	 * We here know what register to save and how much to
 	 * add to the stack.
 	 */
 	addto = offcalc(ipp);
@@ -258,18 +258,18 @@ tlen(NODE *p)
  * Compare two floating point numbers.
  */
 static void
-fcomp(NODE *p)	
+fcomp(NODE *p)
 {
 
 	int swap = ((p->n_su & DORIGHT) != 0);
 	int failjump = attr_find(p->n_ap, ATTR_FP_SWAPPED) != 0;
 
-//printf("fcomp: DOR %d op %s\n", swap, opst[p->n_op]);
+	/* printf("fcomp: DOR %d op %s\n", swap, opst[p->n_op]); */
 	if (p->n_op == GT || p->n_op == GE) {
 		swap ^= 1;
 		p->n_op = (p->n_op == GT ? LT : LE);
 	}
-//printf("fcomp2: DOR %d op %s\n", swap, opst[p->n_op]);
+	/* printf("fcomp2: DOR %d op %s\n", swap, opst[p->n_op]); */
 	if (swap)
 		expand(p, 0, "\tfxch\n");
 
@@ -346,9 +346,9 @@ ultofd(NODE *p)
 
 /*
  * Generate code to convert an SSE float/double to an unsigned long.
- */     
-static void     
-fdtoul(NODE *p) 
+ */
+static void
+fdtoul(NODE *p)
 {
 	if (p->n_left->n_type == FLOAT)
 		E("	movabsq $0x5f000000,A1\n");
@@ -676,7 +676,7 @@ adrput(FILE *io, NODE *p)
 			int r2 = R2UPK2(r);
 			int sh = R2UPK3(r);
 
-			fprintf(io, "(%s,%s,%d)", 
+			fprintf(io, "(%s,%s,%d)",
 			    r1 == MAXREGS ? "" : rnames[r1],
 			    r2 == MAXREGS ? "" : rnames[r2], sh);
 		} else
@@ -926,15 +926,15 @@ char *rnames[MAXREGS] = {
 /* register names for shorter sizes */
 char *rbyte[] = {
 	"%al", "%dl", "%cl", "%bl", "%sil", "%dil", "%bpl", "%spl",
-	"%r8b", "%r9b", "%r10b", "%r11b", "%r12b", "%r13b", "%r14b", "%r15b", 
+	"%r8b", "%r9b", "%r10b", "%r11b", "%r12b", "%r13b", "%r14b", "%r15b",
 };
 char *rshort[] = {
 	"%ax", "%dx", "%cx", "%bx", "%si", "%di", "%bp", "%sp",
-	"%r8w", "%r9w", "%r10w", "%r11w", "%r12w", "%r13w", "%r14w", "%r15w", 
+	"%r8w", "%r9w", "%r10w", "%r11w", "%r12w", "%r13w", "%r14w", "%r15w",
 };
 char *rlong[] = {
 	"%eax", "%edx", "%ecx", "%ebx", "%esi", "%edi", "%ebp", "%esp",
-	"%r8d", "%r9d", "%r10d", "%r11d", "%r12d", "%r13d", "%r14d", "%r15d", 
+	"%r8d", "%r9d", "%r10d", "%r11d", "%r12d", "%r13d", "%r14d", "%r15d",
 };
 
 
@@ -1070,7 +1070,7 @@ myxasm(struct interpass *ip, NODE *p)
 retry:	switch (c) {
 	case 'D': reg = RDI; break;
 	case 'S': reg = RSI; break;
-	case 'A': 
+	case 'A':
 	case 'a': reg = RAX; break;
 	case 'b': reg = RBX; break;
 	case 'c': reg = RCX; break;

--- a/arch/amd64/order.c
+++ b/arch/amd64/order.c
@@ -123,7 +123,7 @@ offstar(NODE *p, int shape)
 		(void)geninsn(p->n_right, INAREG);
 		return; /* Generate (%rbx,%rax) */
 	}
-		
+
 	(void)geninsn(p, INAREG);
 }
 
@@ -171,8 +171,8 @@ myormake(NODE *q)
 	} else if (risreg(p)) {
 		r2 = regno(p);
 		mkconv = 1;
-	} //else
-	//	comperr("bad myormake tree");
+	} /* else */
+	/*	comperr("bad myormake tree"); */
 
 	if (mkconv == 0)
 		return;

--- a/arch/i86/table.c
+++ b/arch/i86/table.c
@@ -211,7 +211,7 @@ struct optab table[] = {
 		"ZT	xor U1,U1\n", },
 
 /* convert char (in register) to double XXX - use NTEMP */
-/* FIXME : need NSPECIAL to force into AL 
+/* FIXME : need NSPECIAL to force into AL
 	check AX:DX right way around ! */
 { SCONV,	INFL,
 		SHCH|SOREG|SNAME,	TCHAR,
@@ -435,7 +435,7 @@ struct optab table[] = {
 		"	movl U1, 10[sp]\n"
 		"	fldcw 4[sp]\n"
 		"	add sp, #16\n", },
- 
+
 
 
 /* slut sconv */
@@ -456,11 +456,11 @@ struct optab table[] = {
 		0,	0,
 		"	call CL\nZC", },
 
-//{ UCALL,	FOREFF,
-//	SCON,	TANY,
-//	SAREG,	TP16,
-//		0,	0,
-//		"	call CL\nZC", },
+/* { UCALL,	FOREFF,
+	SCON,	TANY,
+	SAREG,	TP16,
+		0,	0,
+		"	call CL\nZC", }, */
 
 { CALL,	INAREG,
 		SCON,			TANY,
@@ -787,7 +787,7 @@ struct optab table[] = {
    shifts by 8 16 24 and 32 as moves between registers for
    the bigger types. (eg >> 16 on a long might be mov dx, ax,
    xor ax, ax) */
-   
+
 { LS,		INCREG,
 		SCREG,			T32,
 		SHCH,			T8,
@@ -799,11 +799,11 @@ struct optab table[] = {
    variant, especially including the cost of a) loading cl b) probably
    having to boot something out of cx in the first place. For memory
    its 15+EA v 20 + EA + 4/bit, so the other way.
-   
-   8,16,24 should of course be done by loads.. FIXME 
-   
+
+   8,16,24 should of course be done by loads.. FIXME
+
    Also the compiler keeps generating mov dh, #8, mov cl, dh.. FIXME
-   
+
    For 80186 onwards we have shl reg, immediate (other than 1), 186 shift
    is also much faster */
 
@@ -930,7 +930,7 @@ struct optab table[] = {
 /*
  * The next rules takes care of assignments. "=".
  */
- 
+
 { ASSIGN,	FORCC|FOREFF|INL,
 		SHL,			T32,
 		SMIXOR,			TANY,
@@ -1093,7 +1093,7 @@ struct optab table[] = {
 		"F	mov A1,si\nZQF	mov si,A1\n", },
 
 /*
- * DIV/MOD/MUL 
+ * DIV/MOD/MUL
  */
 /* long div is emulated */
 { DIV,	INCREG,
@@ -1105,14 +1105,14 @@ struct optab table[] = {
 /* REVIEW We can only do (i)divb ax/byte  and (i)divw (dx:ax)/word
    and the results are always in ah/al (remainer/mod)
    or dx:ax (dx = remainer, ax = mod)
-   
+
    Power of two needs to be done by shifts. For other cases of constants
    we need to implement two things
    1. Spotting add sequences for constants with few 1 bits on one side
    2. Spotting cases we can compute the magic constant to multiply with for
       the same result */
-   
-   
+
+
 { DIV,	INAREG,
 		SAREG,			TUNSIGNED|TPOINT,
 		SAREG|SNAME|SOREG,	TUNSIGNED|TPOINT,
@@ -1158,13 +1158,13 @@ struct optab table[] = {
 
 /* (u)long mul is emulated */
 /* On 8086 we can only do multiplies of al * value into ax (for 8bit)
-   or ax * value into dx:ax for 16bit 
-   
+   or ax * value into dx:ax for 16bit
+
    80186 allows us to do a signed multiply of a register with a constant
    into a second register
-   
+
    Same about shifts, and add optimisations applies here too */
-   
+
 /* 32bit mul is emulated (for now) */
 { MUL,		INCREG,
 		SCREG|SNAME|SOREG|SCON,		T32,
@@ -1299,8 +1299,8 @@ struct optab table[] = {
    		sum1 = (sum1 & 0xFFFF) + (sum1 >> 16);
 	writes a pile of crap code.
 */
-   	
-   	
+
+
 { AND,	INCREG|FOREFF,
 		SCREG,			T32,
 		SCREG|SOREG|SNAME,	T32,
@@ -1313,7 +1313,7 @@ struct optab table[] = {
 		0,			RLEFT,
 		"	and AR,AL\n", },
 
-{ AND,	INAREG|FOREFF,  
+{ AND,	INAREG|FOREFF,
 		SAREG|SOREG|SNAME,	T16,
 		SCON|SAREG,		T16,
 		0,			RLEFT,
@@ -1488,7 +1488,7 @@ struct optab table[] = {
  *
  * char has already been promoted to integer types
  */
- 
+
 /* Push immediate not 8086... Loading a register and pushing costs us
    4 + 11 clocks, loading memory would cost us 16 + EA */
 { FUNARG,	FOREFF,

--- a/arch/m16c/code.c
+++ b/arch/m16c/code.c
@@ -255,7 +255,7 @@ bjobcode(void)
 	printf("	NAME gurka.c\n"); /* Don't have the name */
 	for (c = caps; c->cap; c++)
 		printf("	RTMODEL \"%s\", \"%s\"\n", c->cap, c->stat);
-	//printf("	RSEG CODE:CODE:REORDER:NOROOT(0)\n");
+	/* printf("	RSEG CODE:CODE:REORDER:NOROOT(0)\n"); */
 }
 
 /* called just before final exit */
@@ -270,7 +270,7 @@ ejobcode(int flag)
 			continue;
 		printf("	EXTERN %s\n", w->sp->soname);
 	}
-	
+
 	printf("	END\n");
 }
 
@@ -301,7 +301,7 @@ bycode(int t, int i)
 		} else if (lastoctal && '0' <= t && t <= '9') {
 			lastoctal = 0;
 			printf("\"\n\t.ascii \"%c", t);
-		} else {	
+		} else {
 			lastoctal = 0;
 			putchar(t);
 		}

--- a/arch/m16c/local2.c
+++ b/arch/m16c/local2.c
@@ -54,13 +54,13 @@ prologue(struct interpass_prolog *ipp)
     if (p2env.p_regs > 0 && p2env.p_regs != MINRVAR)
 	comperr("fix prologue register savings", p2env.p_regs);
 #endif
-    
+
     printf("	RSEG CODE:CODE:REORDER:NOROOT(0)\n");
-    if (ipp->ipp_flags & IF_VISIBLE)	
+    if (ipp->ipp_flags & IF_VISIBLE)
 	printf("	PUBLIC %s\n", ipp->ipp_name);
     printf("%s:\n", ipp->ipp_name);
-    
-#if 0	
+
+#if 0
     if (xsaveip) {
 	/* Optimizer running, save space on stack */
 	addto = (p2maxautooff - AUTOINIT)/SZCHAR;
@@ -86,17 +86,17 @@ eoftn(struct interpass_prolog *ipp)
 		comperr("fix eoftn register savings %x", p2env.p_regs);
 #endif
 
-	//	if (xsaveip == 0)
+	/* if (xsaveip == 0) */
 	addto = (p2maxautooff - AUTOINIT)/SZCHAR;
 
 	/* return from function code */
-	//deflab(ipp->ipp_ip.ip_lbl);   //XXX - is this necessary?
-	
+	/* deflab(ipp->ipp_ip.ip_lbl);   XXX - is this necessary? */
+
 	/* If retval is a pointer and not a function pointer, put in A0 */
 	if (ISPTR(DECREF(ipp->ipp_type)) &&
 	    !ISFTN(DECREF(DECREF(ipp->ipp_type))))
 	    printf("	mov.w r0,a0\n");
-	
+
 	/* struct return needs special treatment */
 	if (ftype == STRTY || ftype == UNIONTY) {
 		comperr("fix struct return in eoftn");
@@ -104,11 +104,11 @@ eoftn(struct interpass_prolog *ipp)
 		printf("	exitd\n");
 
 	/* Prolog code */
-	//	if (xsaveip == 0) {
+	/* if (xsaveip == 0) { */
 		deflab(ftlab1);
 		printf("	enter #%d\n", addto);
 		printf("	jmp.w " LABFMT "\n", ftlab2);
-		//}
+	/* } */
 }
 
 /*
@@ -210,7 +210,7 @@ twollcomp(NODE *p)
 		cb1 = LT;
 		cb2 = GT;
 		break;
-	
+
 	default:
 		cb1 = cb2 = 0; /* XXX gcc */
 	}
@@ -528,7 +528,7 @@ special(NODE *p, int shape)
 	return SRNOPE;
 }
 
-void    
+void
 myreader(NODE *p)
 {
 	NODE *q, *r, *s, *right;
@@ -551,7 +551,7 @@ myreader(NODE *p)
 		q = mklnode(OREG, (freetemp(szty(right->n_type))),
 		    FPREG, right->n_type);
 		s = mkbinode(ASSIGN, q, right, right->n_type);
-		r = talloc(); 
+		r = talloc();
 		*r = *q;
 		p->n_right = r;
 		pass2_compile(ipnode(s));
@@ -606,10 +606,10 @@ gclass(TWORD t)
 {
 	if (t == CHAR || t == UCHAR)
 		return CLASSC;
-	
+
 	if(ISPTR(t))
 		return CLASSB;
-	
+
 	return CLASSA;
 }
 

--- a/arch/m16c/order.c
+++ b/arch/m16c/order.c
@@ -97,7 +97,7 @@ offstar(NODE *p, int shape)
 int
 shumul(NODE *p, int shape)
 {
-//	NODE *l = p->n_left;
+	/* NODE *l = p->n_left; */
 
 #ifdef PCC_DEBUG
 	if (x2debug) {
@@ -265,7 +265,7 @@ nspecial(struct optab *q)
 	    }*/
 	comperr("multiplication not implemented");
 	break;
-	
+
     default:
 	break;
     }
@@ -299,7 +299,7 @@ gencall(NODE *p, NODE *prev)
 		/* swap arguments on some hardop-converted insns */
 		/* Normal call, just push args and be done with it */
 		p->n_op = UCALL;
-//printf("call\n");
+		/* printf("call\n"); */
 		/* Check if left can be evaluated directly */
 		if (p->n_left->n_op == UMUL) {
 			TWORD t = p->n_left->n_type;
@@ -311,7 +311,7 @@ gencall(NODE *p, NODE *prev)
 		}
 		gencall(p->n_left, p);
 		p->n_rval = storearg(p->n_right);
-//printf("end call\n");
+		/* printf("end call\n"); */
 		break;
 
 	case UFORTCALL:
@@ -334,7 +334,7 @@ gencall(NODE *p, NODE *prev)
 			n = mkbinode(ASSIGN, mklnode(REG, 0, STKREG, INT),
 			    mkbinode(MINUS, mklnode(REG, 0, STKREG, INT),
 			    mklnode(ICON, p->n_stsize, 0, INT), INT), INT);
-//printf("stsize %d\n", p->n_stsize);
+			/* printf("stsize %d\n", p->n_stsize); */
 			pass2_compile(ipnode(n));
 		} else if (prev->n_op == STASG) {
 			n = prev->n_left;
@@ -378,7 +378,7 @@ gencall(NODE *p, NODE *prev)
 			*prev = *p;
 			nfree(n);
 		}
-//printf("end stcall\n");
+		/* printf("end stcall\n"); */
 		break;
 
 	default:
@@ -391,7 +391,7 @@ gencall(NODE *p, NODE *prev)
 
 /*
  * Create separate node trees for function arguments.
- * This is partly ticky, the strange calling convention 
+ * This is partly ticky, the strange calling convention
  * may cause a bunch of code reorganization here.
  */
 static int
@@ -440,7 +440,7 @@ storearg(NODE *p)
 			sz += 2;
 		} else /* long, double */
 			sz += 4;
-			
+
 	}
 
 	/*
@@ -546,7 +546,7 @@ storearg(NODE *p)
 	/* move args to registers */
 	for (i = 0; i < stk; i++) {
 		t = narry[i]->n_type;
-		pass2_compile(ipnode(mkbinode(ASSIGN, 
+		pass2_compile(ipnode(mkbinode(ASSIGN,
 		    mklnode(REG, 0, rary[i], t), narry[i], t)));
 	}
 	return sz;

--- a/arch/m16c/table.c
+++ b/arch/m16c/table.c
@@ -26,7 +26,7 @@ struct optab table[] = {
 	SANY,		TINT|TPOINT,
 		NAREG,	RESC1,
 		"	mov.b AL, A1\n", },
-    
+
 /* unsigned char -> long */
 { SCONV,	INAREG,
 	SCREG,		TUCHAR,
@@ -124,7 +124,7 @@ struct optab table[] = {
 	SAREG|SNAME|SOREG,	TL,
 		0,	RLEFT,
 		"	not.w AR,AL\n	not.w UR,UL\n", },
-	
+
 { OPSIMP,	INAREG|FOREFF,
 	SAREG,			TWORD|TPOINT,
 	SAREG|SNAME|SOREG|SCON,	TWORD|TPOINT,
@@ -133,26 +133,26 @@ struct optab table[] = {
 
 /* XXX - Is this rule really correct? Having a SAREG shape seems kind of
    strange. Doesn't work. Gives a areg as A1. */
-#if 0	
+#if 0
 { OPSIMP,	INBREG,
 	SAREG,			TWORD|TPOINT,
 	SAREG|SBREG|SNAME|SOREG|SCON,	TWORD|TPOINT,
 		NBREG,	RESC1,
 		"	++Ow AR,A1\n", },
 #endif
-	
+
 { OPSIMP,	INBREG,
 	SBREG,			TWORD|TPOINT,
 	SAREG|SBREG|SNAME|SOREG|SCON,	TWORD|TPOINT,
 		0,	RLEFT,
 		"	Ow AR,AL\n", },
-	
+
 { OPSIMP,	INCREG|FOREFF,
 	SCREG,			TCH,
 	SCREG|SNAME|SOREG|SCON,	TCH,
 		0,	RLEFT,
 		"	Ob AR,AL\n", },
-	
+
 /* XXX - Do these work? check nspecial in order.c */
 /* signed integer division */
 { DIV,		INAREG,
@@ -160,7 +160,7 @@ struct optab table[] = {
 	SAREG|SNAME|SOREG,	TWORD,
 	  /*2*NAREG|NASL|*/NSPECIAL,		RLEFT,
 		"	div.w AR\n	mov.w r0,AL\n", },
-      //		"	xor.w r2\n	div.w AR\n", },
+      /* "	xor.w r2\n	div.w AR\n", }, */
 
 
 /* signed integer/char division - separate entry for FOREFF */
@@ -177,9 +177,9 @@ struct optab table[] = {
 	SCREG|SNAME|SOREG,	TCH,
 		2*NCREG|NCSL|NSPECIAL,		RLEFT,
 		"	div.b AR\n\tmov.b r0l,AL\n", },
-      //		"	xor.w r2\n	div.w AR\n", },
+      /* "	xor.w r2\n	div.w AR\n", }, */
 #endif
-	
+
 /* signed integer modulus, equal to above */
 { MOD,		INAREG,
 	SAREG,			TINT,
@@ -313,13 +313,13 @@ struct optab table[] = {
 	SANY,	TANY,
 	SCON|SNAME|SOREG|SAREG|SBREG,	TWORD|TPOINT,
 		NAREG,	RESC1,
-		"	mov.w AR,A1\n", },	
+		"	mov.w AR,A1\n", },
 
 { OPLTYPE,	INBREG,
 	SANY,	TANY,
 	SBREG|SCON|SNAME|SOREG|SAREG,	TWORD|TPOINT,
 		NBREG,	RESC1,
-		"	mov.w AR,A1\n", },	
+		"	mov.w AR,A1\n", },
     /*
 { OPLTYPE,	INAREG,
 	SANY,		TANY,
@@ -333,13 +333,13 @@ struct optab table[] = {
 		NBREG,	RESC1,
 		"	mov.b AR,A1\n", },
     */
-    
+
 { OPLTYPE,	INCREG,
 	SANY,			TANY,
 	SCON|SNAME|SOREG,	TCHAR|TUCHAR,
 		NCREG,	RESC1,
 		"	mov.b AR,A1\n", },
-    
+
 { COMPL,	INAREG,
 	SAREG,	TWORD,
 	SANY,		TANY,
@@ -351,7 +351,7 @@ struct optab table[] = {
 	SANY,		TANY,
 		0,	RLEFT,
 		"	not.b AL\n", },
-	
+
 /* Push function address */
 { FUNARG,	FOREFF,
 	SCON,	TFTN,
@@ -397,7 +397,7 @@ struct optab table[] = {
 	SCON,	TFTN,
 		0,	RLEFT,
 		"ZD", },
-    
+
 { ASSIGN,	INBREG,
 	SBREG,	TFTN,
 	SCON,	TFTN,
@@ -415,7 +415,7 @@ struct optab table[] = {
 	SBREG|SAREG|SOREG|SNAME,	TFTN,
 		0,	RLEFT,
 		"	mov.w AR,AL\n	mov.w UR,UL\n", },
-    
+
 { ASSIGN,	INAREG,
 	SBREG|SAREG|SOREG|SNAME,	TFTN,
 	SAREG,	TFTN,
@@ -446,7 +446,7 @@ struct optab table[] = {
 	SBREG,	TL,
 		0,	RRIGHT,
 		"	mov.w AR,AL\n	mov.w UR,UL\n", },
-    
+
 { ASSIGN,	FOREFF,
 	SBREG|SAREG|SOREG|SNAME,	TL,
 	SCON|SBREG|SAREG|SOREG|SNAME,	TL,
@@ -464,7 +464,7 @@ struct optab table[] = {
 	SCON,	TANY,
 		0,	RLEFT,
 		"	mov.w AR,AL\n", },
-    
+
 { ASSIGN,	FOREFF,
 	SNAME|SOREG,	TWORD|TPOINT,
 	SCON,		TANY,
@@ -490,7 +490,7 @@ struct optab table[] = {
 	SOREG|SNAME,	TWORD|TPOINT,
 		0,	RLEFT,
 		"	mov.w AR,AL\n", },
-    
+
 { ASSIGN,	FOREFF|INAREG,
 	SOREG|SNAME,	TWORD|TPOINT,
 	SAREG,	TWORD|TPOINT,
@@ -502,7 +502,7 @@ struct optab table[] = {
 	SBREG,	TWORD|TPOINT,
 		0,	RRIGHT,
 		"	mov.w AR,AL\n", },
-    
+
 { ASSIGN,	FOREFF|INCREG,
 	SOREG|SNAME,	TCHAR|TUCHAR,
 	SCREG,	TCHAR|TUCHAR,
@@ -520,7 +520,7 @@ struct optab table[] = {
         SBREG,  TWORD|TPOINT,
                 0,      RRIGHT,
                 "	mov.w AR,AL\n", },
-	
+
 { UMUL, 	INAREG,
 	SBREG,	TPOINT|TWORD,
 	SANY,  	TFTN,
@@ -544,13 +544,13 @@ struct optab table[] = {
 	SANY,	TCHAR|TUCHAR,
 		NAREG,	RESC1,
     		"	mov.b [AL], A1\n", },
-    
+
 { UCALL,	FOREFF,
 	SCON,	TANY,
 	SANY,	TANY,
 		0,	0,
 		"	jsr.w CL\nZB", },
-    
+
 { UCALL,	INAREG,
 	SCON,	TANY,
 	SANY,	TANY,
@@ -566,9 +566,9 @@ struct optab table[] = {
 { UCALL,        FOREFF,
 	SNAME|SOREG,	TANY,
 	SANY,		TANY,
-		0,     0,  
+		0,     0,
 		"	jsri.a AL\nZB", },
-    
+
 { UCALL,        INAREG,
 	SBREG,   TANY,
 	SANY,   TANY,
@@ -581,7 +581,7 @@ struct optab table[] = {
 		0,     0,
 		"	jsri.a [AL]\nZB", },
 
-    
+
 { FREE, FREE,	FREE,	FREE,	FREE,	FREE,	FREE,	FREE,	"help; I'm in trouble\n" },
 };
 

--- a/arch/mips/local2.c
+++ b/arch/mips/local2.c
@@ -328,7 +328,7 @@ static void
 starg(NODE *p)
 {
 	int sz = attr_find(p->n_ap, ATTR_P2STRUCT)->iarg(0);
-	//assert(p->n_rval == A1);
+	/* assert(p->n_rval == A1); */
 	printf("\tsubu %s,%s,%d\n", rnames[SP], rnames[SP], sz);
 	/* A0 = dest, A1 = src, A2 = len */
 	printf("\tmove %s,%s\n", rnames[A0], rnames[SP]);
@@ -561,7 +561,7 @@ emulop(NODE *p)
 	else if (p->n_op == RS && p->n_type == LONGLONG) ch = "ashrdi3";
 	else if (p->n_op == RS && (p->n_type == LONG || p->n_type == INT))
 		ch = "ashrsi3";
-	
+
 	else if (p->n_op == DIV && p->n_type == LONGLONG) ch = "divdi3";
 	else if (p->n_op == DIV && (p->n_type == LONG || p->n_type == INT))
 		ch = "divsi3";
@@ -626,7 +626,7 @@ twollcomp(NODE *p)
 		cb1 = LT;
 		cb2 = GT;
 		break;
-	
+
 	default:
 		cb1 = cb2 = 0; /* XXX gcc */
 	}
@@ -1130,7 +1130,7 @@ rmove(int s, int d, TWORD t)
 			print_reg64name(stdout, s, 0);
 			printf("\t# 64-bit rmove\n");
                         printf("\tmove ");
-			print_reg64name(stdout, d, 1); 
+			print_reg64name(stdout, d, 1);
 			printf(",");
 			print_reg64name(stdout, s, 1);
 			printf("\n");
@@ -1272,7 +1272,7 @@ argsiz(NODE *p)
 	if (sz == 8 && (size & 7) != 0)
 		sz += 4;
 
-//	printf("size=%d, sz=%d -> %d\n", size, sz, size + sz);
+	/* printf("size=%d, sz=%d -> %d\n", size, sz, size + sz); */
 	return (size + sz);
 }
 

--- a/arch/mips64/local2.c
+++ b/arch/mips64/local2.c
@@ -305,7 +305,7 @@ static void
 starg(NODE *p)
 {
 	int sz = attr_find(p->n_ap, ATTR_P2STRUCT)->iarg(0);
-	//assert(p->n_rval == A1);
+	/* assert(p->n_rval == A1); */
 	printf("\tdsubu %s,%s,%d\n", rnames[SP], rnames[SP], sz);
 	/* A0 = dest, A1 = src, A2 = len */
 	printf("\tmove %s,%s\n", rnames[A0], rnames[SP]);
@@ -516,7 +516,7 @@ emulop(NODE *p)
 {
 	char *ch = NULL;
 
-	if (p->n_op == LS && (DEUNSIGN(p->n_type) == LONG || 
+	if (p->n_op == LS && (DEUNSIGN(p->n_type) == LONG ||
 	    DEUNSIGN(p->n_type) == LONGLONG))
 		ch = "ashldi3";
 	else if (p->n_op == LS && DEUNSIGN(p->n_type) == INT)
@@ -531,7 +531,7 @@ emulop(NODE *p)
 		ch = "ashrdi3";
 	else if (p->n_op == RS && p->n_type == INT)
 		ch = "ashrsi3";
-	
+
 	else if (p->n_op == DIV && (p->n_type == LONG || p->n_type == LONGLONG))
 		ch = "divdi3";
 	else if (p->n_op == DIV && p->n_type == INT)
@@ -599,7 +599,7 @@ twollcomp(NODE *p)
 		cb1 = LT;
 		cb2 = GT;
 		break;
-	
+
 	default:
 		cb1 = cb2 = 0; /* XXX gcc */
 	}
@@ -1104,7 +1104,7 @@ rmove(int s, int d, TWORD t)
 			print_reg64name(stdout, s, 0);
 			printf("\t# 64-bit rmove\n");
                         printf("\tmove ");
-			print_reg64name(stdout, d, 1); 
+			print_reg64name(stdout, d, 1);
 			printf(",");
 			print_reg64name(stdout, s, 1);
 			printf("\n");
@@ -1246,7 +1246,7 @@ argsiz(NODE *p)
 	if (sz == 8 && (size & 7) != 0)
 		sz += 8;
 
-//	printf("size=%d, sz=%d -> %d\n", size, sz, size + sz);
+	/* printf("size=%d, sz=%d -> %d\n", size, sz, size + sz); */
 	return (size + sz);
 }
 

--- a/arch/nova/code.c
+++ b/arch/nova/code.c
@@ -125,7 +125,7 @@ defzero(struct symtab *sp)
 }
 
 
-//static int ac3temp;
+/* static int ac3temp; */
 /*
  * code for the end of a function
  * deals with struct return here
@@ -134,7 +134,7 @@ void
 efcode(void)
 {
 	P1ND *p, *q;
-//	int sz;
+	/* int sz; */
 
 #if 0
 	/* restore ac3 */
@@ -152,13 +152,13 @@ cerror("efcode");
 	/* create a call to memcpy() */
 	/* will get the result in eax */
 	p = block(REG, NULL, NULL, CHAR+PTR, 0, 0);
-//	p->n_rval = EAX;
+	/* p->n_rval = EAX; */
 	q = block(OREG, NULL, NULL, CHAR+PTR, 0, 0);
-//	q->n_rval = EBP;
+	/* q->n_rval = EBP; */
 	slval(q, 8); /* return buffer offset */
 	p = block(CM, q, p, INT, 0, 0);
-//	sz = (tsize(STRTY, cftnsp->sdf, cftnsp->ssue)+SZCHAR-1)/SZCHAR;
-//	p = block(CM, p, bcon(sz), INT, 0, 0);
+	/* sz = (tsize(STRTY, cftnsp->sdf, cftnsp->ssue)+SZCHAR-1)/SZCHAR; */
+	/* p = block(CM, p, bcon(sz), INT, 0, 0); */
 	p->n_right->n_name = "";
 	p = block(CALL, bcon(0), p, CHAR+PTR, 0, 0);
 	p->n_left->n_name = "memcpy";
@@ -173,7 +173,7 @@ cerror("efcode");
 void
 bfcode(struct symtab **a, int n)
 {
-//	P1ND *p, *q;
+	/* P1ND *p, *q; */
 	int i;
 
 	for (i = 0; i < n; i++) {

--- a/arch/pdp10/local2.c
+++ b/arch/pdp10/local2.c
@@ -108,7 +108,7 @@ prologue(int regs, int autos)
 		printf("L%d:\n", ftlab2);
 	} else {
 		/*
-		 * We here know what register to save and how much to 
+		 * We here know what register to save and how much to
 		 * add to the stack.
 		 */
 		autos = autos + (SZINT-1);
@@ -318,9 +318,9 @@ ptrcomp(NODE *p)
  * Do a binary comparision of two long long, and jump accordingly.
  * XXX - can optimize for constants.
  */
-static void     
+static void
 twollcomp(NODE *p)
-{       
+{
 	int o = p->n_op;
 	int iscon = p->n_right->n_op == ICON;
 	int m = 0; /* XXX gcc */
@@ -381,7 +381,7 @@ twollcomp(NODE *p)
 	    o == LT || o == GT ? 'e' : ' ');
 	upput(getlr(p, 'L'), SZLONG);
 	putchar(',');
-	if (iscon)  
+	if (iscon)
 		printf("[ .long ");
 	upput(getlr(p, 'R'), SZLONG);
 	if (iscon)
@@ -468,8 +468,8 @@ emitshort(NODE *p)
 		if (off >= 0700000000000LL && p->n_name[0] != '\0') {
 			cerror("emitsh");
 			/* reg contains index integer */
-//			if (!istreg(reg))
-//				cerror("emitshort !istreg");
+			/* if (!istreg(reg)) */
+			/* cerror("emitshort !istreg"); */
 			printf("	adjbp %s,[ .long 0%llo+%s ]\n",
 			    rnames[reg], off, p->n_name);
 			printf("	ldb ");
@@ -525,7 +525,7 @@ storeshort(NODE *p)
 		printf("	hr%cm ", off & 1 ? 'r' : 'l');
 		setlval(l, getlval(l) / 2);
 		adrput(stdout, getlr(p, 'R'));
-		putchar(',');   
+		putchar(',');
 		adrput(stdout, getlr(p, 'L'));
 		putchar('\n');
 		return;
@@ -562,7 +562,7 @@ storeshort(NODE *p)
 /*
  * Multiply a register with a constant.
  */
-static void     
+static void
 imuli(NODE *p)
 {
 	NODE *r = p->n_right;
@@ -581,7 +581,7 @@ imuli(NODE *p)
 /*
  * Divide a register with a constant.
  */
-static void     
+static void
 idivi(NODE *p)
 {
 	NODE *r = p->n_right;
@@ -625,7 +625,7 @@ xmovei(NODE *p)
 }
 
 static void
-printcon(NODE *p) 
+printcon(NODE *p)
 {
 	CONSZ cz;
 
@@ -651,7 +651,7 @@ printcon(NODE *p)
 
 static void
 putcond(NODE *p)
-{               
+{
 	char *c = 0; /* XXX gcc */
 
 	switch (p->n_op) {
@@ -763,7 +763,7 @@ zzzcode(NODE *p, int c)
 	case 'U':
 		emitshort(p);
 		break;
-		
+
 	case 'V':
 		storeshort(p);
 		break;
@@ -1055,7 +1055,7 @@ adrput(FILE *fp, NODE *p)
 		}
 		if (p->n_name[0] != '\0')
 			fprintf(fp, "%s", p->n_name);
-		if (getlval(p) < 0) 
+		if (getlval(p) < 0)
 			acon(fp, p);
 		if (p->n_name[0] == '\0' && getlval(p) == 0)
 			putc('0', fp);
@@ -1109,7 +1109,7 @@ optim2(NODE *p, void *arg)
 		    m == DOUBLE || m == STRTY || m == UNIONTY ||
 		    m == UNSIGNED || m == ULONG || m == ULONGLONG) &&
 		    (ml == INT || ml == LONG || ml == LONGLONG || ml == FLOAT ||
-		    ml == DOUBLE || ml == STRTY || ml == UNIONTY || 
+		    ml == DOUBLE || ml == STRTY || ml == UNIONTY ||
 		    ml == UNSIGNED || ml == ULONG ||
 		    ml == ULONGLONG) && ISPTR(l->n_type)) {
 			*p = *l;

--- a/arch/pdp11/local.c
+++ b/arch/pdp11/local.c
@@ -196,7 +196,7 @@ clocal(NODE *p)
 		p->n_op = ASSIGN;
 		p->n_right = p->n_left;
 		p->n_left = block(REG, NIL, NIL, p->n_type, 0, 0);
-		p->n_left->n_rval = p->n_left->n_type == BOOL ? 
+		p->n_left->n_rval = p->n_left->n_type == BOOL ?
 		    RETREG(CHAR) : RETREG(p->n_type);
 		break;
 
@@ -251,9 +251,9 @@ andable(NODE *p)
 int
 cisreg(TWORD t)
 {
-//	if (t == FLOAT || t == DOUBLE || t == LDOUBLE ||
-//	    t == LONGLONG || t == ULONGLONG)
-//		return 0; /* not yet */
+	/* if (t == FLOAT || t == DOUBLE || t == LDOUBLE ||
+	t == LONGLONG || t == ULONGLONG)
+	return 0;  not yet */
 	return 1;
 }
 
@@ -429,7 +429,7 @@ ctype(TWORD type)
 }
 
 void
-calldec(NODE *p, NODE *q) 
+calldec(NODE *p, NODE *q)
 {
 }
 

--- a/arch/pdp7/table.c
+++ b/arch/pdp7/table.c
@@ -588,7 +588,7 @@ struct optab table[] = {
 		"F	movl %esi,A1\nZQF	movl A1,%esi\n", },
 
 /*
- * DIV/MOD/MUL 
+ * DIV/MOD/MUL
  */
 /* long long div is emulated */
 { DIV,	INCREG,
@@ -606,9 +606,9 @@ struct optab table[] = {
 { DIV,		INAREG,
 	SAREG,		TWORD,
 	SNAME,		TWORD,
-		0,      RLEFT,		// XXX, how to rewrite to do the
-					// operands in reverse order?
-					// I tried RRIGHT and lac AL, no good
+		0,      RLEFT,		/* XXX, how to rewrite to do the */
+					/* operands in reverse order? */
+					/* I tried RRIGHT and lac AL, no good */
 		"	lmq\n"
 		"	lac AR\n"
 		"	dac .+4\n"
@@ -765,13 +765,13 @@ struct optab table[] = {
 		0,	RLEFT,
 		"	andl AR,AL\n", },
 
-{ AND,	INAREG|FOREFF,  
+{ AND,	INAREG|FOREFF,
 	SAREG|SOREG|SNAME,	TSHORT|TUSHORT,
 	SCON|SAREG,		TSHORT|TUSHORT,
 		0,	RLEFT,
 		"	andw AR,AL\n", },
 
-{ AND,	INAREG|FOREFF,  
+{ AND,	INAREG|FOREFF,
 	SAREG,			TSHORT|TUSHORT,
 	SAREG|SOREG|SNAME,	TSHORT|TUSHORT,
 		0,	RLEFT,

--- a/arch/powerpc/code.c
+++ b/arch/powerpc/code.c
@@ -94,7 +94,7 @@ setseg(int seg, char *name)
 	case TLSUDATA: name = ".section .tbss,\"awT\",@nobits"; break;
 	case CTORS: name = ".section\t.ctors,\"aw\",@progbits"; break;
 	case DTORS: name = ".section\t.dtors,\"aw\",@progbits"; break;
-	case NMSEG: 
+	case NMSEG:
 		printf("\t.section %s,\"a%c\",@progbits\n", name,
 		    cftnsp ? 'x' : 'w');
 		return;
@@ -238,7 +238,7 @@ int tmpnr;
 		p = block(UMUL, p, NIL, ULONGLONG, 0, 0);
 		p = buildtree(ASSIGN, p, q);
 		ecomp(p);
-		
+
 		t = tempnode(0, sym->stype, sym->sdf, sym->sap);
 		tmpnr = regno(t);
 		p = block(REG, NIL, NIL,
@@ -259,13 +259,13 @@ int tmpnr;
 	}
 
 	(*argofsp) += 2;
-	
+
 	sym->soffset = tmpnr;
 	sym->sflags |= STNODE;
-	
+
 #elif defined(MACHOABI)
 	int fpr = *arg_fprp;
-	
+
 	if (fpr < NFPARGREGS) {
 
 		q = block(REG, NIL, NIL, sym->stype, sym->sdf, sym->sss);
@@ -275,7 +275,7 @@ int tmpnr;
 			sym->soffset = regno(p);
 			sym->sflags |= STNODE;
 		} else {
-			//cerror("param64bit called without dotemps");
+			/* cerror("param64bit called without dotemps"); */
 			p = nametree(sym);
 		}
 		p = buildtree(ASSIGN, p, q);
@@ -294,7 +294,7 @@ int tmpnr;
 #else
 #error no ABI in arch/powerpc/code.c:param_double()
 #endif
-	
+
 }
 
 /* setup a float param on the stack
@@ -421,7 +421,7 @@ bfcode(struct symtab **sp, int cnt)
          */
 	if (cftnsp->sdf->dlst)
 		saveallargs = pr_hasell(cftnsp->sdf->dlst);
-printf("; saveallargs: %d, cnt: %d\n", saveallargs, cnt);		
+printf("; saveallargs: %d, cnt: %d\n", saveallargs, cnt);
 	if (cftnsp->stype == STRTY+FTN || cftnsp->stype == UNIONTY+FTN) {
 		param_retstruct();
 		++arg_gpr;
@@ -449,7 +449,7 @@ printf("; saveallargs: %d, cnt: %d\n", saveallargs, cnt);
 #ifndef ELFABI
 		int spclass = sp[i]->sclass;
 #endif
-	
+
 		if ((arg_gpr >= NARGREGS) && !xtemps)
 				break;
 
@@ -464,15 +464,15 @@ printf("; saveallargs: %d, cnt: %d\n", saveallargs, cnt);
 #if defined(ELFABI)
 				param_double(sp[i], &arg_gpr, xtemps && !saveallargs);
 
-#else			
+#else
 			{
 				param_double(sp[i], &arg_fpr, xtemps && !saveallargs);
 				/* ABI calls for space in GPRs */
 				if (spclass != EXTDEF)
-					arg_gpr+=2;	
+					arg_gpr+=2;
 			}
 #endif
-			
+
 			else
 				param_64bit(sp[i], &arg_gpr, xtemps && !saveallargs);
 		} else if (sptype == FLOAT) {
@@ -611,7 +611,7 @@ ejobcode(int flag)
 `	 */
 	struct stub *p;
 
-	DLIST_FOREACH(p, &stublist, link) { 
+	DLIST_FOREACH(p, &stublist, link) {
 		printf("\t.section __TEXT, __picsymbolstub1,symbol_stubs,pure_instructions,32\n");
 		printf("\t.align 5\n");
 		printf("\"L%s$stub\":\n", p->name);
@@ -697,7 +697,7 @@ bycode(int t, int i)
 		} else if (lastoctal && '0' <= t && t <= '9') {
 			lastoctal = 0;
 			printf("\"\n\t.ascii \"%c", t);
-		} else {	
+		} else {
 			lastoctal = 0;
 			putchar(t);
 		}
@@ -939,11 +939,11 @@ mrst_rec(int num, struct swents **p, int n, int *state, int lab)
 
 	DPRINTF(("generating table with %d elements\n", tblsize));
 
-	// AND with Wmax
+	/* AND with Wmax */
 	t = tempnode(num, UNSIGNED, 0, 0);
 	r = buildtree(AND, t, bcon(Wmax));
 
-	// RS lowbits
+	/* RS lowbits */
 	r = buildtree(RS, r, bcon(lowbit));
 
 	t = tempnode(0, UNSIGNED, 0, 0);
@@ -979,7 +979,7 @@ mrst_rec(int num, struct swents **p, int n, int *state, int lab)
 	ecomp(r);
 
 	plabel(tbllabel);
-	
+
 	mrst_put_entry_and_recurse(num, p, n, state, tbllabel, lab,
 		0, tblsize, Wmax, lowbit);
 }
@@ -1109,7 +1109,7 @@ mrst_find_window(struct swents **p, int n, int *state, int lab, int *len, int *l
 
 	for (; b > 0; b >>= 1, no_b--) {
 
-		// select the next bit
+		/* select the next bit */
 		W |= b;
 		L += 1;
 
@@ -1416,7 +1416,7 @@ movearg_double(NODE *p, int *fregp, int *regp, int sclass)
 	 * compiled to handle soft-float.
 	 */
 
-#if defined(MACHOABI)// && defined(SOFTFLOAT)
+#if defined(MACHOABI) /* && defined(SOFTFLOAT) */
 	/* don't move floats for local functions */
 
 	if (sclass == EXTDEF)
@@ -1457,7 +1457,7 @@ movearg_double(NODE *p, int *fregp, int *regp, int sclass)
 	(*regp) += 2;
 
 #endif
-	
+
 	return p;
 }
 
@@ -1558,13 +1558,13 @@ moveargs(NODE *p, int *regp, int *fregp, int sclass)
 
 	if (reg > R10 && r->n_op != STARG) {
 	  *rp = pusharg(r, regp);
-                
+
 	} else if (r->n_op == STARG) {
 		*rp = movearg_struct(r, regp);
-		
+
 	} else if (DEUNSIGN(r->n_type) == LONGLONG) {
 	  *rp = movearg_64bit(r, regp);
-                
+
 	} else if (r->n_type == DOUBLE || r->n_type == LDOUBLE) {
 		if (features(FEATURE_HARDFLOAT))
 #ifndef MACHOABI
@@ -1574,7 +1574,7 @@ moveargs(NODE *p, int *regp, int *fregp, int sclass)
 #endif
 		else
             *rp = movearg_64bit(r, regp);
-            
+
 	} else if (r->n_type == FLOAT) {
 		if (features(FEATURE_HARDFLOAT))
 			*rp = movearg_float(r, fregp, regp);

--- a/arch/powerpc/local.c
+++ b/arch/powerpc/local.c
@@ -63,7 +63,7 @@ getsoname(struct symtab *sp)
 	struct attr *ap;
 	return (ap = attr_find(sp->sap, ATTR_SONAME)) ?
 	    ap->sarg(0) : sp->sname;
-	
+
 }
 
 #if defined(MACHOABI)
@@ -154,21 +154,21 @@ int def = EXTERN;
 		sp = picsymtab("\"L", name, buf1);
 		addstub(&stublist, name);
 	}
-	
+
 	q = block(REG, NIL, NIL, PTR+VOID, 0, 0);
 	regno(q) = PICREG;
 	r = xbcon(0, sp, INT);
-	q = buildtree(PLUS, q, r);		
+	q = buildtree(PLUS, q, r);
 	q->n_sp->sclass = def;
-	
+
 
 /* the code below adds an extra indirection
  * that loads a PowerPC instruction into CTR
  * instead of the address to that instruction
  */
-//	if (p->n_sp->sclass != EXTDEF) {
-	//	q = block(UMUL, q, 0, PTR+VOID, 0, 0);
-	//}
+	/* if (p->n_sp->sclass != EXTDEF) { */
+	/* q = block(UMUL, q, 0, PTR+VOID, 0, 0); */
+	/* } */
 
 #endif
 	q = block(UMUL, q, 0, p->n_type, p->n_df, p->n_ap);
@@ -202,7 +202,7 @@ picstatic(NODE *p)
 	sp->sclass = STATIC;
 	sp->stype = p->n_sp->stype;
 	q = xbcon(0, sp, PTR+VOID);
-	
+
 	q = block(UMUL, q, 0, p->n_type, p->n_df, p->n_ap);
 	q->n_sp = p->n_sp;
 	p1nfree(p);
@@ -226,16 +226,16 @@ picstatic(NODE *p)
 	}
 	sp->sclass = STATIC;
 	sp->stype = p->n_sp->stype;
-	
+
 	q = block(REG, NIL, NIL, PTR+VOID, 0, 0);
 	regno(q) = PICREG;
 
 	r = xbcon(0, sp, INT);
 	q = buildtree(PLUS, q, r);
 	q = block(UMUL, q, 0, p->n_type, p->n_df, p->n_ap);
-	
+
 	q->n_sp = p->n_sp;
-//printf("; q = 0x%x, q->n_sp = 0x%x\n", q, q->n_sp);
+/* printf("; q = 0x%x, q->n_sp = 0x%x\n", q, q->n_sp); */
 	nfree(p);
 
 #endif
@@ -391,7 +391,7 @@ printf("; breaking\n");
 			if (ISFTN(DECREF(q->stype)))
 				break;
 #endif
-		case EXTERN: 
+		case EXTERN:
 			if (kflag == 0)
 				break;
 			if (blevel > 0)
@@ -432,7 +432,7 @@ printf("; breaking\n");
 		ecomp(r);
 #endif
 		break;
-		
+
 	case CBRANCH:
 		l = p->n_left;
 
@@ -489,7 +489,7 @@ printf("; breaking\n");
 		nfree(p);
 		p = l;
 		break;
-		
+
 	case SCONV:
 		l = p->n_left;
 
@@ -584,7 +584,7 @@ printf("; breaking\n");
 		p->n_op = ASSIGN;
 		p->n_right = p->n_left;
 		p->n_left = block(REG, NIL, NIL, p->n_type, 0, 0);
-		p->n_left->n_rval = p->n_left->n_type == BOOL ? 
+		p->n_left->n_rval = p->n_left->n_type == BOOL ?
 		    RETREG(BOOL_TYPE) : RETREG(p->n_type);
 		break;
 
@@ -643,20 +643,20 @@ fixnames(NODE *p, void *arg)
 
 	    q->n_right->n_op == ICON) {
 			sp = q->n_right->n_sp;
-			
+
 #endif
 
 			if (sp == NULL)
 					return; /* nothing to do */
 			if (sp->sclass == STATIC && !ISFTN(sp->stype))
 					return; /* function pointer */
-			
+
 			if (sp->sclass != STATIC && sp->sclass != EXTERN &&
 				sp->sclass != EXTDEF)
 					cerror("fixnames");
 			c = NULL;
 #if defined(ELFABI)
-			
+
 			if ((ap2 = attr_find(sp->sap, ATTR_SONAME)) == NULL ||
 				(c = strstr(ap2->sarg(0), "@got(31)")) == NULL)
 							cerror("fixnames2");
@@ -666,10 +666,10 @@ fixnames(NODE *p, void *arg)
 				*c = 0;
 
 #elif defined(MACHOABI)
-	
+
 			if (!ISFTN(sp->stype))
 				return; /* function pointer */
-		
+
 			if ((ap2 = attr_find(sp->sap, ATTR_SONAME)) == NULL ||
 		    	(c = strchr(ap2->sarg(0), '$')) == NULL)
 					cerror("fixnames2: %p %s", ap2, c);
@@ -678,7 +678,7 @@ fixnames(NODE *p, void *arg)
 				addstub(&stublist, getexname(sp)+1);
 				memcpy(c, "$stub", sizeof("$stub"));
 			}
-			
+
 			nfree(q->n_left);
 			q = q->n_right;
 			if (isu)
@@ -700,18 +700,18 @@ myp2tree(NODE *p)
 {
 	int o = p->n_op;
 	struct symtab *sp;
-	
+
 #if defined(ELFABI)
 	if (kflag)
 		p1walkf(p, fixnames, 0);
 #endif
-		
-	if (o != FCON) 
+
+	if (o != FCON)
 		return;
 
 	/* Write float constants to memory */
 	/* Should be voluntary per architecture */
- 
+
 	sp = IALLOC(sizeof(struct symtab));
 	sp->sclass = STATIC;
 	sp->sap = 0;
@@ -733,7 +733,7 @@ myp2tree(NODE *p)
 #endif
 
 	p->n_op = NAME;
-	slval(p, 0);	
+	slval(p, 0);
 	p->n_sp = sp;
 }
 
@@ -788,7 +788,7 @@ spalloc(NODE *t, NODE *p, OFFSZ off)
 	q = block(REG, NIL, NIL, PTR+INT, 0, 0);
 	regno(q) = SPREG;
 	q = block(UMUL, q, NIL, INT, 0, 0);
-	
+
 	/* save old top-of-stack value to new top-of-stack position */
 	r = block(REG, NIL, NIL, PTR+INT, 0, 0);
 	regno(r) = SPREG;
@@ -814,8 +814,8 @@ spalloc(NODE *t, NODE *p, OFFSZ off)
  * C-style escape sequences. (which it doesn't!)
  * Location is already set.
  */
- 
-#if !(defined(MACHOABI)) 
+
+#if !(defined(MACHOABI))
 void
 instring(struct symtab *sp)
 {
@@ -875,7 +875,7 @@ ninval(CONSZ off, int fsz, NODE *p)
 		uerror("element not constant");
 
 	switch (t) {
-	
+
 		case FLOAT:
 		case DOUBLE:
 		case LDOUBLE:
@@ -973,7 +973,7 @@ ctype(TWORD type)
 }
 
 void
-calldec(NODE *p, NODE *q) 
+calldec(NODE *p, NODE *q)
 {
 #ifdef PCC_DEBUG
 	if (xdebug)

--- a/arch/powerpc/local2.c
+++ b/arch/powerpc/local2.c
@@ -107,7 +107,7 @@ static TWORD ftype;
 void
 prologue(struct interpass_prolog *ipp)
 {
-int i, sz, addto = p2framesize; //p2maxautooff;
+int i, sz, addto = p2framesize; /* p2maxautooff; */
 
 #ifdef PCC_DEBUG
 	if (x2debug)
@@ -121,13 +121,13 @@ int i, sz, addto = p2framesize; //p2maxautooff;
 			ipp->ip_tmpnum,
 			ipp->ip_lblnum);
 
-	printf("; p2framesize = %d, p2calls = %d, p2autooff = %d\n", 
+	printf("; p2framesize = %d, p2calls = %d, p2autooff = %d\n",
 			p2framesize, p2calls, p2autooff);
 #endif
 
 	if (p2framesize == 0)
 		return; /* no need to create a stack frame */
-				
+
 #if defined(ELFABI)
 
 	sz = p2autooff;
@@ -161,7 +161,7 @@ int i, sz, addto = p2framesize; //p2maxautooff;
 		/* get return address (not required for leaf function) */
 		printf("\tmflr %s\n", rnames[R0]);
 		printf("\tstw %s,4(%s)\n", rnames[R0], rnames[R1]);
-		
+
 		if (kflag) {
 		/* save registers R30 and R31 */
 			printf("\tstmw %s,-8(%s)	; save GOTREG\n", rnames[GOTREG], rnames[FPREG]);
@@ -170,9 +170,9 @@ int i, sz, addto = p2framesize; //p2maxautooff;
 		}
 	}
 
-	
+
 #elif defined(MACHOABI)
-	/* 
+	/*
 	 * Mach-O defines a "linkage area" where the LR, CR and SP are saved.
 	 * This area is used by the CALLEE but MUST be included in the stack
 	 * area of the CALLER.  Additionally, values are stored in slightly
@@ -192,21 +192,21 @@ int i, sz, addto = p2framesize; //p2maxautooff;
 	 */
 	char* scratch;
 	sz = 4;
-	
+
 	if (p2calls) {
-	 
+
 		printf("\tmflr  %s			; save the link register\n", rnames[R0]);
 		printf("\tstw   %s,8(%s)\n", rnames[R0],rnames[SPREG]);
 		printf("\tmfcr  %s			; save the condition register\n", rnames[R0]);
 		printf("\tstw   %s,4(%s)\n", rnames[R0],rnames[SPREG]);
-#if 0 //defined(FPREG)	 
+#if 0 /* defined(FPREG) */
 		/* Mach-O does not use a frame pointer, but pcc does. */
 		printf("\tmr %s,%s	; preserve FPREG\n", rnames[R0], rnames[FPREG]);
 		printf("\tmr %s,%s	; establish new frame pointer\n", rnames[FPREG], rnames[SPREG]);
 #endif
 
-		
-#if 0 // defined(FPREG)
+
+#if 0 /* defined(FPREG) */
 		printf("\tstw %s,-4(%s)		; save PICREG relative to frame pointer\n", rnames[PICREG], rnames[FPREG]);
 		printf("\tstw %s,-8(%s)		; save FPREG relative to frame pointer\n", rnames[R0], rnames[FPREG]);
 		scratch = rnames[FPREG];
@@ -224,7 +224,7 @@ int i, sz, addto = p2framesize; //p2maxautooff;
 #endif
 	}
 
-	/* save non-volatile registers from the frame/stack pointer down */	
+	/* save non-volatile registers from the frame/stack pointer down */
 	/* stmw is an option for saving off multiple registers but slower than stw */
 printf("; p2env.p_regs = 0x%x%x\n", p2env.p_regs[0], p2env.p_regs[1]);
 	for (i = 0; i < MAXREGS; i++) {
@@ -232,11 +232,11 @@ printf("; p2env.p_regs = 0x%x%x\n", p2env.p_regs[0], p2env.p_regs[1]);
 			sz += (SZLONG/SZCHAR);
 			if (sz == addto)
 				cerror("collision between stack and frame");
-		
+
 			printf("\tstw %s,-%d(%s)\n", rnames[i], sz, scratch);
 		}
 	}
-	
+
 	if (p2calls) {
 		/* create the new stack frame */
 		if (addto > 32767) {
@@ -249,7 +249,7 @@ printf("; p2env.p_regs = 0x%x%x\n", p2env.p_regs[0], p2env.p_regs[1]);
 			printf("\tstwu %s,-%d(%s)	; move the stack pointer\n", rnames[SPREG], addto, rnames[SPREG]);
 		}
 	}
-	
+
 	printf("\tbcl 20,31,\"L%s$pb\"\n", ipp->ipp_name + 1);
 	printf("\"L%s$pb\":\n", ipp->ipp_name + 1);
 	printf("\tmflr %s\n", rnames[PICREG]);
@@ -294,13 +294,13 @@ int idx = 1;
 		goto noframe; /* no need to create a stack frame */
 
 	/* struct return needs special treatment */
-	if (ftype == STRTY || ftype == UNIONTY) 
+	if (ftype == STRTY || ftype == UNIONTY)
 		cerror("eoftn");
-	
+
 
 #if defined(ELFABI)
 
-	sz =  = p2autooff;
+	sz = p2autooff;
 
 	/* calculate the frame space */
 	for (i = 0; i < MAXREGS; i++) {
@@ -308,8 +308,8 @@ int idx = 1;
 				addto += SZLONG/SZCHAR;
 		}
 	}
-	
-	/* unwind stack frame */	
+
+	/* unwind stack frame */
 	for (i = 0; i < MAXREGS; i++) {
 		if (TESTBIT(p2env.p_regs, i)) {
 			sz += (SZLONG/SZCHAR);
@@ -317,47 +317,47 @@ int idx = 1;
 				cerror("collision between stack and frame");
 			printf("\tlwz %s, -%d(%s)\n", rnames[i], sz, rnames[SPREG]);
 		}
-	}	
+	}
 	if (kflag) {
 		printf("\tlwz %s,-8(%s)	; restore GOTREG\n", rnames[GOTREG], rnames[FPREG]);
 	}
 #if defined(FPREG)
 	printf("\tlwz %s,-4(%s)	; restore FPREG\n", rnames[FPREG], rnames[FPREG]);
 #endif
-	
+
 	printf("\tlwz %s,4(%s)	; reload stack pointer\n", rnames[R0], rnames[SPREG]);
 	printf("\tmtlr %s		; restore link register\n", rnames[R0]);
 	printf("\tlwz %s,0(%s)	; restore stack pointer\n", rnames[SPREG], rnames[SPREG]);
-	
+
 	if (p2calls) {
-		
+
 		printf("\tlwz %s,4(%s)	; restore condition register\n", rnames[R0], rnames[SPREG]);
 		printf("\tmtcr %s\n", rnames[R0]);
 		printf("\tlwz %s,8(%s)	; reload link register\n", rnames[R0], rnames[SPREG]);
-	
+
 		printf("\tmtlr %s			; restore link register\n", rnames[R0]);
 	} else {
 		/* restore the R31 we might have used with PIC labels*/
-		//printf("\tlwz %s,-4(%s)\n", rnames[R31], rnames[SPREG]);
+		/* printf("\tlwz %s,-4(%s)\n", rnames[R31], rnames[SPREG]); */
 		printf("\tmr %s, %s\n", rnames[R31], rnames[R0]);
 	}
-	
+
 	printf("\tlwz %s,4(%s)	; reload stack pointer\n", rnames[R0], rnames[SPREG]);
 	printf("\tmtlr %s		; restore link register\n", rnames[R0]);
 	printf("\tlwz %s,0(%s)	; restore stack pointer\n", rnames[SPREG], rnames[SPREG]);
-	
-	
-	
-	
+
+
+
+
 #elif defined(MACHOABI)
 
 	sz = 4;
 
 	for (i = 0; i < MAXREGS; i++) {
 		if (TESTBIT(p2env.p_regs, i))
-			idx++; 
+			idx++;
 	}
-	
+
 	if (p2calls > 0)
 		idx++;
 
@@ -368,12 +368,12 @@ int idx = 1;
 				addto += SZLONG/SZCHAR;
 		}
 	}
-	
+
 	for (i = 0; i < MAXREGS; i++) {
 		if (TESTBIT(p2env.p_regs, i))
-			idx++; 
+			idx++;
 	}
-	
+
 	if (p2calls > 0)
 		idx++;
 
@@ -383,7 +383,7 @@ int idx = 1;
 		/* unwind stack frame */
 		printf("\tlwz %s,0(%s)	; restore stack pointer\n", rnames[SPREG], rnames[SPREG]);
 		printf("\tlwz %s,-4(%s)	; restore PICREG\n", rnames[PICREG], rnames[SPREG]);
-				
+
 		/* restore other registers */
 
 #if 1
@@ -403,7 +403,7 @@ int idx = 1;
 			if (sz == 0)
 				cerror("collision unwinding stack");
 			printf("\tlwz %s, -%d(%s)\n", rnames[i], sz, rnames[SPREG]);
-			--idx; 
+			--idx;
 		}
 	}
 #endif
@@ -411,11 +411,11 @@ int idx = 1;
 		printf("\tlwz %s,4(%s)	; restore condition register\n", rnames[R0], rnames[SPREG]);
 		printf("\tmtcr %s\n", rnames[R0]);
 		printf("\tlwz %s,8(%s)	; reload link register\n", rnames[R0], rnames[SPREG]);
-	
+
 		printf("\tmtlr %s			; restore link register\n", rnames[R0]);
 	} else {
 		/* restore the R31 we might have used with PIC labels*/
-		//printf("\tlwz %s,-4(%s)\n", rnames[R31], rnames[SPREG]);
+		/* printf("\tlwz %s,-4(%s)\n", rnames[R31], rnames[SPREG]); */
 		printf("\tmr %s, %s\n", rnames[R31], rnames[R0]);
 	}
 
@@ -430,7 +430,7 @@ int idx = 1;
 
 
 
-noframe:	
+noframe:
 	printf("\tblr\n");
 }
 
@@ -534,7 +534,7 @@ twollcomp(NODE *p)
 		cb1 = LT;
 		cb2 = GT;
 		break;
-	
+
 	default:
 		cb1 = cb2 = 0; /* XXX gcc */
 	}
@@ -639,7 +639,7 @@ stasg(NODE *p)
 	    printf("\tbl L%s$stub\n", EXPREFIX "memcpy");
 		addstub(&stublist, EXPREFIX "memcpy");
 #endif
-	
+
 }
 
 static void
@@ -785,7 +785,7 @@ emul(NODE *p)
         else if (p->n_op == RS && p->n_type == LONGLONG) ch = "ashrdi3";
         else if (p->n_op == RS && (p->n_type == LONG || p->n_type == INT))
                 ch = "ashrsi3";
-        
+
         else if (p->n_op == DIV && p->n_type == LONGLONG) ch = "divdi3";
         else if (p->n_op == DIV && (p->n_type == LONG || p->n_type == INT))
                 ch = "divsi3";
@@ -886,7 +886,7 @@ ftou(NODE *p)
 		else
 			expand(p, 0, "\tlfd A3,");
 		printf("-4(%s)\n", rnames[SPREG]);
-		
+
 	} else {
 		if (l->n_type == FLOAT)
 			expand(p, 0, "\tlfs A3,AL\n");
@@ -1250,7 +1250,7 @@ reg64name(int reg, int hi)
 	if ((hi == HIREG && !features(FEATURE_BIGENDIAN)) ||
 	    (hi == LOWREG && features(FEATURE_BIGENDIAN)))
 		off = 1;
-		
+
 	printf("%s" , rnames[idx + off]);
 }
 
@@ -1261,7 +1261,7 @@ reg64name(int reg, int hi)
 void
 upput(NODE *p, int size)
 {
-//	size /= SZCHAR;
+	/* size /= SZCHAR; */
 	switch (p->n_op) {
 	case REG:
 		reg64name(regno(p), HIREG);
@@ -1327,7 +1327,7 @@ adrput(FILE *io, NODE *p)
 		return;
 
 	case REG:
-	//printf("xxxxx reg %d\n", regno(p));
+	/* printf("xxxxx reg %d\n", regno(p)); */
 		if (GCLASS(regno(p)) == CLASSB)
 			reg64name(regno(p), LOWREG);
 		else
@@ -1398,7 +1398,7 @@ argsize(NODE *p, n_regs *nr)
 	if (t == FLOAT) {
 		nr->fpr += 1;
 		return 4;
-	}		
+	}
 	if (t < LONGLONG ||  t > BTMASK){
 		nr->gpr += 1;
 		return 4;
@@ -1423,9 +1423,9 @@ static int
 calc_args_size(NODE *p, n_regs *nr)
 {
 	int n = 0;
-        
+
         if (p->n_op == CM) {
-                //n += calc_args_size(p->n_left, nr);
+                /* n += calc_args_size(p->n_left, nr); */
                 n += calc_args_size(p->n_right, nr);
                 /* uncount the function call */
                 nr->gpr -= 1;
@@ -1479,7 +1479,7 @@ storefloat(struct interpass *ip, NODE *p)
 
 #define ISF(p) ((p)->n_type == FLOAT || (p)->n_type == DOUBLE || \
 (p)->n_type == LDOUBLE)
-	
+
 		if (ISF(p->n_left) && ISF(p->n_right) && l && r) {
 			/* must store one. store left */
 			struct interpass *nip;
@@ -1529,7 +1529,7 @@ myreader(struct interpass *ipole)
 #endif
 		if (( nr.gpr > max_gpr) || (nr.fpr > max_fpr )) {
 			/* have to sync max_fpr with max _gpr */
-			max_gpr = nr.gpr; 
+			max_gpr = nr.gpr;
 			max_fpr = nr.fpr;
 			if (max_fpr > NFPARGREGS)
 				comperr("too many floating point args\n");
@@ -1538,15 +1538,15 @@ myreader(struct interpass *ipole)
 		storefloat(ip, ip->ip_node);
 	}
 
-//	if (p2maxstacksize < NARGREGS*SZINT/SZCHAR)
-	//	p2maxstacksize = NARGREGS*SZINT/SZCHAR;
+	/* if (p2maxstacksize < NARGREGS*SZINT/SZCHAR) */
+	/* p2maxstacksize = NARGREGS*SZINT/SZCHAR; */
 
 
 #ifdef PCC_DEBUG
 	if (x2debug)
 		printf("max_gpr = %d, max_fpr = %d\n", max_gpr, max_fpr);
 #endif
-	
+
 #ifndef MACHOABI
 	/* calculate the frame space */
 	for (i = 0; i < MAXREGS; i++) {
@@ -1558,9 +1558,9 @@ myreader(struct interpass *ipole)
 	p2framesize = NARGREGS*(SZINT/SZCHAR);
 	p2framesize += NFPARGREGS*(SZDOUBLE/SZCHAR);
 #endif
-	
+
 	if (p2calls != 0) {
-#ifndef MACHOABI 
+#ifndef MACHOABI
 		p2framesize += 8;	/* stack ptr / return addr */
 #else
 		p2framesize += 12;	/* stack ptr / condition register/ return addr */
@@ -1572,18 +1572,18 @@ myreader(struct interpass *ipole)
 		p2framesize += 4;	/* GOTREG/R31 */
 #endif
 	}
-	
+
 	if (max_gpr > NARGREGS) {
-		p2framesize += (SZINT/SZCHAR)*(max_gpr - NARGREGS);		
+		p2framesize += (SZINT/SZCHAR)*(max_gpr - NARGREGS);
 	}
-	
+
 	p2framesize += p2maxautooff;		/* autos */
 	p2framesize += p2temps;			/* TEMPs that aren't autos */
-	
-	/* create the new stack frame */	
+
+	/* create the new stack frame */
 	p2framesize = (p2framesize+15) & ~15; /* 16-byte aligned */
-	//p2maxautooff = p2framesize;
-	
+	/* p2maxautooff = p2framesize; */
+
 #if 1
 	printf(";;; MYREADER\n");
 	printf(";;; p2maxautooff = %d\n", p2maxautooff);

--- a/arch/powerpc/table.c
+++ b/arch/powerpc/table.c
@@ -65,7 +65,7 @@
 
 struct optab table[] = {
 /* First entry must be an empty entry */
-{ -1, FOREFF, SANY, TANY, SANY, TANY, 0, 0, "", }, 
+{ -1, FOREFF, SANY, TANY, SANY, TANY, 0, 0, "", },
 
 /* PCONVs are not necessary */
 { PCONV,	INAREG,
@@ -131,48 +131,48 @@ struct optab table[] = {
 { SCONV,	INAREG,
 	SAREG,	TCHAR,
 	SAREG,	TUSHORT|TUWORD,
-		NLA0,	RESC1, //NSPECIAL|NAREG|NASL
+		NLA0,	RESC1, /* NSPECIAL|NAREG|NASL */
 		"	extsb A1,AL" COM "convert char to ushort/unsigned\n", },
 
 { SCONV,	INBREG | FEATURE_BIGENDIAN,
 	SAREG,	TUCHAR|TUSHORT|TUNSIGNED,
 	SBREG,	TLONGLONG|TULONGLONG,
-		NEEDS(NREG(B, 1)), RESC1, // NBREG
+		NEEDS(NREG(B, 1)), RESC1, /* NBREG */
 		"	mr U1,AL" COM "convert uchar/ushort/uint to (u)longlong\n"
 		"	li A1,0\n", },
 
 { SCONV,	INBREG,
 	SAREG,	TUCHAR|TUSHORT|TUNSIGNED,
 	SBREG,	TLONGLONG|TULONGLONG,
-		NEEDS(NREG(B, 1)), RESC1, //NBREG
+		NEEDS(NREG(B, 1)), RESC1, /* NBREG */
 		"	mr A1,AL" COM "convert uchar/ushort/uint to (u)longlong\n"
 		"	li U1,0\n", },
 
 { SCONV,	INBREG | FEATURE_BIGENDIAN,
 	SAREG,	TCHAR|TSHORT|TSWORD,
 	SBREG,	TULONGLONG|TLONGLONG,
-		NEEDS(NREG(B, 1)), RESC1, // NBREG
+		NEEDS(NREG(B, 1)), RESC1, /* NBREG */
 		"	mr U1,AL" COM "convert char/short/int to ulonglong\n"
 		"	srawi A1,AL,31\n", },
 
 { SCONV,	INBREG,
 	SAREG,	TCHAR|TSHORT|TSWORD,
 	SBREG,	TULONGLONG|TLONGLONG,
-		NEEDS(NREG(B, 1)), RESC1, // NBREG
+		NEEDS(NREG(B, 1)), RESC1, /* NBREG */
 		"	mr A1,AL" COM "convert char/short/int to ulonglong\n"
 		"	srawi U1,AL,31\n", },
 
 { SCONV,	INAREG,
 	SAREG,	TSHORT|TUSHORT,
 	SAREG,	TCHAR|TUCHAR,
-		NLA0,	RESC1,	//NSPECIAL|NAREG|NASL
+		NLA0,	RESC1,	/* NSPECIAL|NAREG|NASL */
 		"	andi. A1,AL,255" COM "convert (u)short to (u)char\n", },
 
 /* extsh copies bit 16 of AL to upper 16 bits of A1 */
 { SCONV,	INAREG,
 	SAREG,	TSHORT,
 	SAREG,	TWORD,
-		NEEDS(NREG(A, 1), NEVER(R0)),	RESC1,  // NAREG|NASL
+		NEEDS(NREG(A, 1), NEVER(R0)),	RESC1,  /* NAREG|NASL */
 		"	extsh A1,AL" COM "convert short to int\n", },
 
 { SCONV,	INAREG,
@@ -344,7 +344,7 @@ struct optab table[] = {
 	SAREG,	TWORD,
 		NSCAA,	RESC1,
 		"ZF", },
-	
+
 { SCONV,	INCREG | FEATURE_HARDFLOAT,
 	SBREG,	TLONGLONG|TULONGLONG,
 	SCREG,	TFLOAT|TDOUBLE|TLDOUBLE,
@@ -436,7 +436,7 @@ struct optab table[] = {
 	SCREG,	TFLOAT|TDOUBLE|TLDOUBLE,
 		XSL(C),	RESC1,	/* should be 0 */
 		"	bl CL" COM "call (no args, result) to scon\n", },
-		
+
 { CALL,		INCREG | FEATURE_HARDFLOAT,
 	SCREG,	TFLOAT|TDOUBLE|TLDOUBLE,
 	SCREG,	TFLOAT|TDOUBLE|TLDOUBLE,
@@ -497,7 +497,7 @@ struct optab table[] = {
 		"	mtctr AL" COM "ucall (no args, result) to ctr\n"
 		"	bctrl\n", },
 
-	
+
 { CALL,		INCREG | FEATURE_HARDFLOAT,
 	SAREG, TFTN,
 	SCREG, TFLOAT|TDOUBLE|TLDOUBLE,
@@ -790,7 +790,7 @@ struct optab table[] = {
 /*
  * The next rules takes care of assignments. "=".
  */
- 
+
 
 { ASSIGN,	FOREFF|INAREG,
 	SAREG,		TWORD|TPOINT|TSHORT|TUSHORT|TCHAR|TUCHAR,
@@ -1051,7 +1051,7 @@ struct optab table[] = {
 		"	mr UL,UR\n", },
 
 /*
- * DIV/MOD/MUL 
+ * DIV/MOD/MUL
  */
 
 { DIV,	INAREG,

--- a/arch/riscv/code.c
+++ b/arch/riscv/code.c
@@ -107,7 +107,7 @@ setseg(int seg, char *name)
 	case TLSUDATA: name = ".section .tbss,\"awT\",@nobits"; break;
 	case CTORS: name = ".section\t.ctors,\"aw\",@progbits"; break;
 	case DTORS: name = ".section\t.dtors,\"aw\",@progbits"; break;
-	case NMSEG: 
+	case NMSEG:
 		printf("\t.section %s,\"a%c\",@progbits\n", name,
 		    cftnsp ? 'x' : 'w');
 		return;
@@ -142,7 +142,7 @@ static void
 putintemp(struct symtab *sym)
 {
 	NODE *p;
-	//cerror("putintemps called, not supported");
+	/* cerror("putintemps called, not supported"); */
 	p = tempnode(0, sym->stype, sym->sdf, sym->sap);
 	p = buildtree(ASSIGN, p, nametree(sym));
 	sym->soffset = regno(p->n_left);
@@ -199,7 +199,7 @@ static void
 param_32bit(struct symtab *sym, int *argofsp, int dotemps)
 {
 	NODE *p, *q;
-	
+
 	q = block(REG, NIL, NIL, sym->stype, sym->sdf, sym->sap);
 	regno(q) = A0 + (*argofsp)++;
 	if (dotemps) {
@@ -207,7 +207,7 @@ param_32bit(struct symtab *sym, int *argofsp, int dotemps)
 		sym->soffset = regno(p);
 		sym->sflags |= STNODE;
 	} else {
-		//cerror("param32bit called without dotemps");
+		/* cerror("param32bit called without dotemps"); */
 		p = nametree(sym);
 	}
 	p = buildtree(ASSIGN, p, q);
@@ -231,7 +231,7 @@ param_double(struct symtab *sym, int *argofsp, int dotemps)
 				sym->soffset = regno(p);
 				sym->sflags |= STNODE;
 			} else {
-				//cerror("param64bit called without dotemps");
+				/* cerror("param64bit called without dotemps"); */
 				p = nametree(sym);
 			}
 			p = buildtree(ASSIGN, p, q);
@@ -330,7 +330,7 @@ param_struct(struct symtab *sym, int *argofsp)
 	num = sz > navail ? navail : sz;
 	if (sz > 2)
 		printf("passed as reference (%d)\n", sz);
-		
+
 	for (i = 0; i < num; i++) {
 		q = block(REG, NIL, NIL, INT, 0, 0);
 		regno(q) = A0 + argofs++;
@@ -383,7 +383,7 @@ bfcode(struct symtab **sp, int cnt)
 			break;
 
 		if (argofs >= NARGREGS) {
-			//cerror("too many arguments, do something intelligent");
+			/* cerror("too many arguments, do something intelligent"); */
 				putintemp(sp[i]);
 		} else if (sstype == STRTY || sstype == UNIONTY) {
 				param_struct(sp[i], &argofs);
@@ -391,23 +391,23 @@ bfcode(struct symtab **sp, int cnt)
 				param_64bit(sp[i], &argofs, dotemps);
 		} else if (sstype == DOUBLE || sstype == LDOUBLE ||  sstype == FLOAT) {
 				param_double(sp[i], &fargofs, dotemps);
-//		} else if (sstype == FLOAT) {
-//				param_float(sp[i], &argofs, dotemps);
+		/* } else if (sstype == FLOAT) { */
+		/* param_float(sp[i], &argofs, dotemps); */
 		} else {
 				param_32bit(sp[i], &argofs, dotemps);
 		}
-		
+
 	} /*  for (i = 0; i < cnt; i++) */
 
 	/* if saveallargs, save the rest of the args onto the stack */
 	if (saveallargs) {
 		off = NARGREGS*ARGINIT/SZINT;
-		off = (off+15) & ~15; /* 16-byte aligned */ 
+		off = (off+15) & ~15; /* 16-byte aligned */
 		p = block(REG, NIL, NIL, INT, 0, 0);
 		regno(p) = SP;
 		p = buildtree(MINUSEQ, p, bcon(off));
 		ecomp(p);
-		
+
 		while (argofs < NARGREGS ) {
 			/* int off = (ARGINIT+FIXEDSTACKSIZE*SZCHAR)/SZINT + argofs; */
 			off = ARGINIT/SZINT + argofs;
@@ -422,11 +422,11 @@ bfcode(struct symtab **sp, int cnt)
 		}
 
 	}
-	
+
 /* profiling */
 	if (pflag) {
 #if defined(ELFABI) || defined(AOUTABI)
-	
+
 		sp2 = lookup("_mcount", 0);
 		sp2->stype = EXTERN;
 		p = nametree(sp2);
@@ -435,7 +435,7 @@ bfcode(struct symtab **sp, int cnt)
 		p = buildtree(ADDROF, p, NIL);
 		p = block(UCALL, p, NIL, INT, 0, 0);
 		ecomp(funcode(p));
-	
+
 #endif
 	}
 }
@@ -502,11 +502,11 @@ bjobcode(void)
 {
 	DLIST_INIT(&stublist, link);
 	DLIST_INIT(&nlplist, link);
-	
+
 	/* riscv names for some asm constant printouts */
 	astypnames[INT] = astypnames[UNSIGNED] = "\t.long";
 
-}	
+}
 
 #ifdef notdef
 /*
@@ -536,7 +536,7 @@ bycode(int t, int i)
 		} else if (lastoctal && '0' <= t && t <= '9') {
 			lastoctal = 0;
 			printf("\"\n\t.ascii \"%c", t);
-		} else {	
+		} else {
 			lastoctal = 0;
 			putchar(t);
 		}
@@ -701,7 +701,7 @@ pusharg(P1ND *p, int *regp)
 	regno(q) = SP;
 
 	off = SZINT/SZCHAR * (*regp - (A7 + 1));
-//printf("pusharg: off = %d, regp = %d\n", off, *regp);
+	/* printf("pusharg: off = %d, regp = %d\n", off, *regp); */
 
 	if (off > 0)
 		q = block(PLUS, q, bcon(off), INT, 0, 0);
@@ -724,7 +724,7 @@ movearg_32bit(P1ND *p, int *regp)
 	q = buildtree(ASSIGN, q, p);
 
 	*regp = reg;
-  
+
   return q;
 
 }
@@ -743,7 +743,7 @@ movearg_64bit(NODE *p, int *regp)
 	reg &= ~1;
 #endif
 
-//printf("movearg_64bit: reg 0%o\n", reg);
+/* printf("movearg_64bit: reg 0%o\n", reg); */
 
 	if (reg > A7) {
 		*regp = reg;
@@ -807,41 +807,41 @@ movearg_struct(NODE *p, int *regp)
  * 2) aggregates of 2*XLEN passed in two registers
  * 3) aggregates greater than two registers passed by reference
  */
- 
+
 	sz = tsize(p->n_type, p->n_df, p->n_ap) / SZINT;
-	
+
 	printf("walking \n");
-	p1fwalk(p, eprint, 0); 
+	p1fwalk(p, eprint, 0);
 
 	/* remove STARG node */
 	l = p->n_left;
 	p1nfree(p);
 			printf("2 walking \n");
-			p1fwalk(l, eprint, 0); 
+			p1fwalk(l, eprint, 0);
 
 	switch (sz) {
 		case 2:
-			printf("case 2\n");		
+			printf("case 2\n");
 
 			q = block(UMUL, l, NIL, INT, 0, 0);
 			if ((*regp - A0) < NARGREGS)
 				q = movearg_32bit(q, regp);
-			else 
+			else
 				q = pusharg(q, regp);
-			
+
 			/* set-up second field */
 			r = block(REG, NIL, NIL, INT, 0, 0);
 			regno(r) = FP;
 			r = block(MINUS, r, bcon(4), INT, 0, 0);
-			
+
 			q = block(CM, q, r, INT, 0, 0);
 			printf("walking again\n");
 			p1fwalk(q, eprint, 0);
 
 			l = r;
-			
+
 			/* fallthrough */
-			
+
 		case 1:
 			printf("case 1 (%d)\n", (*regp - A0));
 			l = block(UMUL, l, NIL, INT, 0, 0);
@@ -852,16 +852,16 @@ movearg_struct(NODE *p, int *regp)
 			if (sz == 2)
 				q->n_right = l;
 			else
-				q = l;	
-				
+				q = l;
+
 			printf("2 walking again\n");
 			p1fwalk(l, eprint, 0);
-			
+
 			break;
-			
+
 		default:
 			r = l;
-			
+
 			off = ((sz*(SZINT/SZCHAR))+15) & ~15; /* 16-byte aligned */
 			l = block(REG, NIL, NIL, INT, 0, 0);
 			regno(l) = SP;
@@ -933,9 +933,9 @@ movearg_struct(NODE *p, int *regp)
 	}
 
 	q = reverse(q);
-	
+
 	*regp = reg;
-	
+
 #endif
 
 	return q;
@@ -949,7 +949,7 @@ moveargs(NODE *p, int *regp, int *fregp, int *llregp)
 	NODE *r, **rp;
 	int reg, freg, llreg, bottom = 0, top = 0;
 	int numregs;
-	
+
 	if (p->n_op == CM) {
 		recursion_level++;
 		p->n_left = moveargs(p->n_left, regp, fregp, llregp);
@@ -968,8 +968,8 @@ moveargs(NODE *p, int *regp, int *fregp, int *llregp)
 	freg = *fregp;
 	llreg = *llregp;
 	numregs = (A7 - reg) + (DA0 - llreg)*2;
-	
-//printf("movargs: reg = %d, recursion_level = %d, top  = %d, bottom  = %d\n", reg, recursion_level, top, bottom);
+
+/* printf("movargs: reg = %d, recursion_level = %d, top  = %d, bottom  = %d\n", reg, recursion_level, top, bottom); */
 printf("; movargs: reg = %d, numregs %d\n", reg, numregs);
 	if (freg > FA7)
 		cerror("max floating point args exceeded");
@@ -992,7 +992,7 @@ printf("; movargs: reg = %d, numregs %d\n", reg, numregs);
 	}
 
 	if (top) {
-		// clear out stuff if needed
+		/* clear out stuff if needed */
 	}
 
   return straighten(p);
@@ -1048,20 +1048,20 @@ p1arg_overflow(NODE* r)
 	if (! r->n_left)
 		last = 1;
 
-printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n", 
+printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n",
 					r, r->n_op, r->n_left, r->n_right, last);
-return 0;		
+return 0;
 	while (1)  {
-printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n", 
+printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n",
 					r, r->n_op, r->n_left, r->n_right, last);
 		if (q->n_op == STARG) {
-		//printf("STARG\n");
+		/* printf("STARG\n"); */
 			sz = tsize(q->n_type, q->n_df, q->n_ap) / SZINT;
 			switch (sz) {
 				case 1:
 					n_regs += 1;
 					break;
-				case 2: 
+				case 2:
 					n_regs += 2;
 					break;
 				default:
@@ -1070,19 +1070,19 @@ printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n",
 					off += sz * (SZINT/SZCHAR);
 			}
 		} else if (DEUNSIGN(q->n_type) == LONGLONG) {
-		//printf("LONGLONG\n");
+		/* printf("LONGLONG\n"); */
 						n_regs += 2;
 		} else if (q->n_type == DOUBLE || q->n_type == LDOUBLE) {
-		//printf("DOUBLE\n");
+		/* printf("DOUBLE\n"); */
 						n_fregs += 2;
 		} else if (q->n_type == FLOAT) {
-		//printf("FLOAT\n");
+		/* printf("FLOAT\n"); */
 						n_fregs += 1;
 		} else if (q->n_type > 0) {
-		//printf(">0\n");
+		/* printf(">0\n"); */
 						n_regs += 1;
 		}
-		
+
 #if 1
 		if (last)
 			break;
@@ -1094,19 +1094,19 @@ printf("; r: %p, op: %d, n_left: %p n_right: %p last = %d\n",
 			last = 1;
 		}
 #endif
-	} 
-	
-	if (n_fregs > NARGREGS) 
+	}
+
+	if (n_fregs > NARGREGS)
 		n_regs  += n_fregs - NARGREGS;
 
 	if (n_regs > NARGREGS) {
 			off += (n_regs - NARGREGS)*(SZINT/SZCHAR);
-	} 
+	}
 	if (n_fregs > NARGREGS) {
 			off += (n_fregs - NARGREGS)*(SZINT/SZCHAR);
-	}	
-	
-//printf("n_regs: %d, off: %d\n", n_regs, off);
+	}
+
+/* printf("n_regs: %d, off: %d\n", n_regs, off); */
 
 return off;
 
@@ -1124,7 +1124,7 @@ funcode(NODE *p)
 	int llregnum = DA0;
  	NODE *r, *q;
 	int off = 0;
-	
+
 	if (DECREF(p->n_left->n_type) == STRTY+FTN ||
 		DECREF(p->n_left->n_type) == UNIONTY+FTN)
 			p = retstruct(p);
@@ -1132,17 +1132,17 @@ funcode(NODE *p)
 	r = p->n_right;
 	off = p1arg_overflow(r);
 
-	//p1fwalk(r, eprint, 0);
+	/* p1fwalk(r, eprint, 0); */
 	if (off > 0) {
-		off = (off+15) & ~15; /* 16-byte aligned */ 
+		off = (off+15) & ~15; /* 16-byte aligned */
 		q = block(ICON, NIL, NIL, INT, 0, 0);
 		slval(q, off);
 		p->n_right = block(CM, p->n_right, q, INT, 0, 0);
 		p->n_qual = off;
 	}  else
 		p->n_qual = 0;
-	
-//printf("funcode %d, 0x%x\n", off, p->n_right);	
+
+/* printf("funcode %d, 0x%x\n", off, p->n_right); */
 
 	p->n_right = moveargs(p->n_right, &regnum, &fregnum, &llregnum);
 

--- a/arch/riscv/local.c
+++ b/arch/riscv/local.c
@@ -1,6 +1,6 @@
 /*	$Id$	*/
 /*
- * Copyright (c) 2022, Tim Kelly/Dialectronics.com (gtkelly@). 
+ * Copyright (c) 2022, Tim Kelly/Dialectronics.com (gtkelly@).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,7 +22,7 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 /*
  * Copyright (c) 2003 Anders Magnusson (ragge@ludd.luth.se).
  * All rights reserved.
@@ -305,7 +305,7 @@ clocal(NODE *p)
 			p->n_rval = q->soffset;
 			break;
 
-		case EXTERN: 
+		case EXTERN:
 		case EXTDEF:
 			if (kflag == 0)
 				break;
@@ -347,7 +347,7 @@ clocal(NODE *p)
 		ecomp(r);
 #endif
                 break;
-		
+
 	case CBRANCH:
 		l = p->n_left;
 
@@ -368,8 +368,8 @@ clocal(NODE *p)
 				l->n_type = t;
 				l->n_right->n_type = t;
 			}
-		} // else
-//			printf("CBRANCH not handled op: 0%o, left op: 0%o \n", p->n_op, l->n_left->n_op);
+		} /* else */
+		/* printf("CBRANCH not handled op: 0%o, left op: 0%o \n", p->n_op, l->n_left->n_op); */
 
 		break;
 
@@ -406,7 +406,7 @@ clocal(NODE *p)
 		nfree(p);
 		p = l;
 		break;
-		
+
 	case SCONV:
 		l = p->n_left;
 
@@ -500,7 +500,7 @@ clocal(NODE *p)
 		p->n_op = ASSIGN;
 		p->n_right = p->n_left;
 		p->n_left = block(REG, NIL, NIL, p->n_type, 0, 0);
-		p->n_left->n_rval = p->n_left->n_type == BOOL ? 
+		p->n_left->n_rval = p->n_left->n_type == BOOL ?
 		    RETREG(BOOL_TYPE) : RETREG(p->n_type);
 		break;
 
@@ -547,7 +547,7 @@ fixnames(NODE *p, void *arg)
 
         if (q->n_op == ICON) {
                 sp = q->n_sp;
-                
+
 #endif
 
                 if (sp == NULL)
@@ -570,7 +570,7 @@ fixnames(NODE *p, void *arg)
 			memcpy(c, "@plt", sizeof("@plt"));
                 } else
                         *c = 0;
-                        
+
 #endif
         }
 }
@@ -583,12 +583,12 @@ myp2tree(NODE *p)
 
 	if (kflag)
 		p1walkf(p, fixnames, 0);
-	if (o != FCON) 
+	if (o != FCON)
 		return;
 
 	/* Write float constants to memory */
 	/* Should be voluntary per architecture */
- 
+
 	sp = IALLOC(sizeof(struct symtab));
 	sp->sclass = STATIC;
 	sp->sap = 0;
@@ -603,7 +603,7 @@ myp2tree(NODE *p)
 	inval(0, tsize(sp->stype, sp->sdf, sp->sap), p);
 
 	p->n_op = NAME;
-	slval(p, 0);	
+	slval(p, 0);
 	p->n_sp = sp;
 }
 
@@ -651,7 +651,7 @@ spalloc(NODE *t, NODE *p, OFFSZ off)
 	sp->n_rval = SP;
 	t->n_type = sp->n_type;
 	ecomp(buildtree(ASSIGN, t, sp));
-	
+
 #else
 /*
  * Allocate bits on the stack.
@@ -725,8 +725,8 @@ ninval(CONSZ off, int fsz, NODE *p)
 	TWORD t;
 	int i, nbits;
 	uint32_t *ufp;
-//	union { float f; double d; long double l; int i[3]; } u;
-        
+	/* union { float f; double d; long double l; int i[3]; } u; */
+
 	t = p->n_type;
 	if (t > BTMASK)
 		p->n_type = t = INT; /* pointer */
@@ -737,15 +737,15 @@ ninval(CONSZ off, int fsz, NODE *p)
 	switch (t) {
 #ifndef LANG_CXX
 	case FLOAT:
-		
+
 		ufp = soft_toush(p->n_scon, t, &nbits);
 		for (i = 0; i < sztable[t]; i += SZINT) {
 			printf(PRTPREF "%s %d \t" COM " floating point value\n",  astypnames[INT],
 				(i < nbits ? ufp[i/SZINT] : 0));
 		}
 		break;
-#if 0	
-	case DOUBLE:		
+#if 0
+	case DOUBLE:
 		ufp = soft_toush(p->n_scon, t, &nbits);
 		printf(PRTPREF "%s %d \t" COM " double value\n",  astypnames[INT], ufp[0]);
 		for (i = SZINT; i < sztable[t]; i += SZINT) {
@@ -754,7 +754,7 @@ ninval(CONSZ off, int fsz, NODE *p)
 		}
 		break;
 #endif
-#endif	
+#endif
 
 	case LONGLONG:
 	case ULONGLONG:
@@ -776,7 +776,7 @@ ninval(CONSZ off, int fsz, NODE *p)
 		ninval(off+32, 32, p);
 #endif
 		break;
-			
+
 	case INT:
 	case UNSIGNED:
 		printf("\t.long %d", (int)glval(p));
@@ -826,7 +826,7 @@ ctype(TWORD type)
 }
 
 void
-calldec(NODE *p, NODE *q) 
+calldec(NODE *p, NODE *q)
 {
 #ifdef PCC_DEBUG
 	if (xdebug)

--- a/arch/riscv/local2.c
+++ b/arch/riscv/local2.c
@@ -1,6 +1,6 @@
 /*	$Id$	*/
 /*
- * Copyright (c) 2022, Tim Kelly/Dialectronics.com (gtkelly@). 
+ * Copyright (c) 2022, Tim Kelly/Dialectronics.com (gtkelly@).
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -22,7 +22,7 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 /*
  * Copyright (c) 2003 Anders Magnusson (ragge@ludd.luth.se).
  * All rights reserved.
@@ -97,11 +97,11 @@ char *rnames[] = {
 	REGPREFIX "s2", REGPREFIX "s3", REGPREFIX "s4", REGPREFIX "s5",
 	REGPREFIX "s6", REGPREFIX "s7", REGPREFIX "s8", REGPREFIX "s9",
 	REGPREFIX "s10", REGPREFIX "s11",
-	
+
 	/* temp registers */
-	REGPREFIX "t3", REGPREFIX "t4", REGPREFIX "t5", 
+	REGPREFIX "t3", REGPREFIX "t4", REGPREFIX "t5",
 #ifdef SAVE_RA_FOR_LAST
-	REGPREFIX "ra", 
+	REGPREFIX "ra",
 #else
 	REGPREFIX "t6",
 #endif
@@ -111,7 +111,7 @@ char *rnames[] = {
 	REGPREFIX "ft0", REGPREFIX "ft1", REGPREFIX "ft2", REGPREFIX "ft3",
 	REGPREFIX "ft4", REGPREFIX "ft5", REGPREFIX "ft6", REGPREFIX "ft7",
 	/* saved registers */
-	REGPREFIX "fs0", REGPREFIX "fs1", 
+	REGPREFIX "fs0", REGPREFIX "fs1",
 	/* argument registers */
 	REGPREFIX "fa0", REGPREFIX "fa1", REGPREFIX "fa2", REGPREFIX "fa3",
 	REGPREFIX "fa4", REGPREFIX "fa5", REGPREFIX "fa6", REGPREFIX "fa7",
@@ -121,16 +121,16 @@ char *rnames[] = {
 	REGPREFIX "fs10", REGPREFIX "fs11",
 	/* temp registers */
 	REGPREFIX "ft8", REGPREFIX "ft9", REGPREFIX "ft10", REGPREFIX "ft11",
-	
+
 	/* pseudo-registers for longlongs */
 	/* saved registers */
 	REGPREFIX "ds0", REGPREFIX "ds1", REGPREFIX "ds2",  REGPREFIX "ds3",
-	REGPREFIX "ds5", 
+	REGPREFIX "ds5",
 	/* argument registers */
 	REGPREFIX "da0", REGPREFIX "da1", REGPREFIX "da2", REGPREFIX "da3",
 	/* temp registers */
 #ifdef USE_T0_AS_TEMP
-	REGPREFIX "dt0", REGPREFIX "dt1", REGPREFIX "dt2", 
+	REGPREFIX "dt0", REGPREFIX "dt1", REGPREFIX "dt2",
 #else
 	REGPREFIX "xxx", REGPREFIX "dt1", REGPREFIX "dt2"
 #endif
@@ -184,7 +184,7 @@ prologue(struct interpass_prolog *ipp)
 				addto += SZLONG/SZCHAR;
 		}
 	}
-	
+
 	if ((addto == 0) && (p2calls == 0))
 		return; /* no need to create a stack frame */
 	printf(";" TAB "p2maxautooff: %d, addto: %d\n", p2maxautooff, addto);
@@ -194,28 +194,28 @@ prologue(struct interpass_prolog *ipp)
 
 	/* put current frame pointer into temp register */
 	printf(TAB "mv %s, %s\n", rnames[T1], rnames[FP]);
-	
+
 	/* save the stack pointer to the frame pointer */
 	printf(TAB "mv %s, %s\n", rnames[FP], rnames[SP]);
 
 	/* make space for ra */
 	if (p2calls > 0)
 		addto += SZLONG/SZCHAR;
-	
+
 	/* create the new stack frame */
 	addto = (addto+15) & ~15; /* 16-byte aligned */
 	if (addto < 1<<20) {
-		printf(TAB "subi %s, %s, %d\n", rnames[SP], rnames[SP], addto);	
+		printf(TAB "subi %s, %s, %d\n", rnames[SP], rnames[SP], addto);
 	} else {
 		printf(TAB "addi %s, %s, %d\n", rnames[T1], rnames[ZERO], (addto) >> 16);
 		printf(TAB "sll %s,%s,%d\n", rnames[T1], rnames[T1], 16);
 		printf(TAB "addi %s,%s,%d\n", rnames[T1], rnames[ZERO], (addto) & 0xffff);
 		printf(TAB "sub %s,%s,%s\n", rnames[SP], rnames[SP], rnames[T1]);
 	}
-	
+
 	/* stack pointer can grow downward
 	 * frame pointer points to top of the
-	 * stack-based arguments 
+	 * stack-based arguments
 	 */
 
 	/* save the original frame pointer to the bottom of the stack */
@@ -225,14 +225,14 @@ prologue(struct interpass_prolog *ipp)
 		printf(TAB "sw %s, 4(%s)\n", rnames[RA], rnames[SP]);
 		sz += (SZLONG/SZCHAR);
 	}
-		
+
 	/* save non-volatile registers from the bottom of stack up */
 	for (i = 0; i < MAXREGS; i++) {
 		if (TESTBIT(p2env.p_regs, i)) {
 			sz += (SZLONG/SZCHAR);
 			if (sz == addto)
 				cerror("collision between stack and frame");
-		
+
 			printf(TAB "sw %s, %d(%s)\n", rnames[i], sz, rnames[SP]);
 		}
 	}
@@ -260,33 +260,33 @@ int i, sz, idx = 0, addto = p2maxautooff;
 				addto += SZLONG/SZCHAR;
 		}
 	}
-	
+
 	if ((addto == 0) && (p2calls == 0)) {
-		printf(TAB "jr %s\n", rnames[RA]);   
+		printf(TAB "jr %s\n", rnames[RA]);
 		return; /* no stack frame was created */
 	}
 
 	/* struct return needs special treatment */
-	if (ftype == STRTY || ftype == UNIONTY) 
+	if (ftype == STRTY || ftype == UNIONTY)
 		cerror("eoftn");
-		
+
 	for (i = 0; i < MAXREGS; i++) {
 		if (TESTBIT(p2env.p_regs, i))
-			idx++; 
+			idx++;
 	}
-	
+
 	if (p2calls > 0)
 		idx++;
-		
+
 	/* unwind stack frame */
 	for (i = (MAXREGS-1); i >= 0; --i) {
 		if (TESTBIT(p2env.p_regs, i)) {
 			sz = idx*(SZLONG/SZCHAR);
 			if (sz == 0)
 				cerror("collision unwinding stack");
-		
+
 			printf(TAB "lw %s, %d(%s)\n", rnames[i], sz, rnames[SP]);
-			--idx; 
+			--idx;
 		}
 	}
 
@@ -296,14 +296,14 @@ int i, sz, idx = 0, addto = p2maxautooff;
 
 	/* move the original frame pointer to a temp */
 	printf(TAB "lw %s, 0(%s)\n", rnames[T1], rnames[SP]);
-	
+
 	/* restore the stack pointer */
 	printf(TAB "mv %s, %s\n", rnames[SP], rnames[FP]);
-	
+
 	/* restore the frame pointer */
 	printf(TAB "mv %s, %s\n", rnames[FP], rnames[T1]);
 
-	printf(TAB "jr %s\n", rnames[RA]);  
+	printf(TAB "jr %s\n", rnames[RA]);
 
 }
 
@@ -336,7 +336,7 @@ zzzcode(NODE *p, int c)
 	case 'D': /* long long comparision */
 		twollcomp(p);
 		break;
-		
+
 	case 'E': /* generate and error */
 		comperr("zzzcode received ZE macro");
 		break;
@@ -364,15 +364,15 @@ zzzcode(NODE *p, int c)
 			expand(p, 0, " A1, AL, AR");
 		}
 		break;
-		
+
 	case 'Q': /* emit struct assign */
 		printf("%d", attr_find(p->n_ap, ATTR_P2STRUCT)->iarg(0));
 		/* stasg(p); */
 		break;
 
 	case 'R':  /* remove from stack after subroutine call */
-		//printf("zzzcode R %d, 0x%x\n", p->n_qual, p);
-		//fwalk(p, e2print, 0);
+		/* printf("zzzcode R %d, 0x%x\n", p->n_qual, p); */
+		/* fwalk(p, e2print, 0); */
 		if (p->n_qual > 0)
 			printf("\taddi sp, sp, %d\n", p->n_qual);
 		break;
@@ -397,7 +397,7 @@ hopcode(int f, int o)
 	char opcode[20][7] = {"add", "sub", "and", "or", "xor",
 					  "addi", "subi", "andi", "ori", "xori",
 					  "fadd.s", "fsub.s", "andi", "ori", "xori",
-					  "fadd.d", "fsub.d", "andi", "ori", "xori"}; 
+					  "fadd.d", "fsub.d", "andi", "ori", "xori"};
 	int i = 5, j;
 	switch (o) {
 		case PLUS:
@@ -405,7 +405,7 @@ hopcode(int f, int o)
 			break;
 		case MINUS:
 			j = 1;
-			break;	
+			break;
 		case AND:
 			j = 2;
 			break;
@@ -415,7 +415,7 @@ hopcode(int f, int o)
 		case ER:
 			j = 4;
 			break;
-			
+
 	default:
 		comperr("hopcode2: %d", o);
 		return; /* XXX */
@@ -507,8 +507,8 @@ twollcomp(NODE *p)
 	int s = getlab2();
 	int e = p->n_label;
 	int cb1, cb2;
-	
-	o = op = p->n_op;	
+
+	o = op = p->n_op;
 	if (o >= ULE)
 		o -= (ULE-LE);
 	switch (o) {
@@ -530,7 +530,7 @@ twollcomp(NODE *p)
 		cb1 = LT; /* branch to s */
 		cb2 = GT; /* branch to e */
 		break;
-	
+
 	default:
 		cb1 = cb2 = 0; /* XXX gcc */
 	}
@@ -541,12 +541,12 @@ twollcomp(NODE *p)
 	if (cb2)
 		printf(LABFMT, e);
 	printf(COM "compare 64-bit values (upper)\n");
-	
+
 	printf( TAB "%s ", ccbranches[op-EQ]);
 	expand(p, 0, "AL, AR,");
 	printf(LABFMT, e);
 	printf(COM "(and lower)\n");
-	
+
 	deflab(s);
 }
 
@@ -665,10 +665,10 @@ ftoi(NODE *p)
 		if (n_type == FLOAT) { /* single precision */
 			expand(p, 0, TAB "fcvt.w.s A1, AL\n");
 		}
-		else { /* double precision */ 
+		else { /* double precision */
 			expand(p, 0, TAB "fcvt.l.d A1, AL\n");
-		}	
-	}	
+		}
+	}
 	else if (n_op == NAME) {
 		/* comes in as a memory address */
 		/* move the memory address to register A1 */
@@ -679,13 +679,13 @@ ftoi(NODE *p)
 			/* once in A2, operate */
 			expand(p, 0, TAB "fcvt.w.s A1, A2\n");
 		}
-		else{ /* double precision */ 
+		else{ /* double precision */
 			/* move the value into register A2 */
 			expand(p, 0, TAB "fld A2, 0(A1)\n");
 			/* once in A2, operate */
 			expand(p, 0, TAB "fcvt.w.d A1, A2\n");
 		}
-	}	
+	}
 	else if (n_op == OREG) {
 		/* comes in as an offset from the GPR specified in AL */
 		if (n_type == FLOAT) { /* single precision */
@@ -694,14 +694,14 @@ ftoi(NODE *p)
 			/* once in A2, operate */
 			expand(p, 0, TAB "fcvt.w.s A1, A2\n");
 		}
-		else{ /* double precision */ 
+		else{ /* double precision */
 			/* move the value into register A2 */
 			expand(p, 0, TAB "fmv.d.x A2, AL\n");
 			/* once in A2, operate */
 			expand(p, 0, TAB "fcvt.w.d A1, A2\n");
 		}
 	}
-	else 
+	else
 		cerror("unknown n_op in ftoi()\n");
 
 	printf(COM "end conversion\n");
@@ -878,8 +878,8 @@ conput(FILE *fp, NODE *p)
 
 	int val = getlval(p);
 
-//printf("conput %d \n", val);
-//fwalk(p, e2print, 0);
+	/* printf("conput %d \n", val); */
+	/* fwalk(p, e2print, 0); */
 
 	switch (p->n_op) {
 	case ICON:
@@ -919,8 +919,8 @@ reg64name(int reg, int hi)
 	if (hi == HIREG)
 		off = 1;
 
-	//printf("reg64name: %d %s ", reg, off == 1 ? "HIREG" : "LOREG");
-	
+	/* printf("reg64name: %d %s ", reg, off == 1 ? "HIREG" : "LOREG"); */
+
 	if (reg > MAXREGS) {
 		cerror("maxregs exceeded in reg64name");
 		return; /* XXX */
@@ -929,7 +929,7 @@ reg64name(int reg, int hi)
 		switch (reg) {
 			default:
 				idx = S2 + 2*(reg - DS1);
-		}		
+		}
 	}
 	else if (reg >= DT0) {
 		switch(reg) {
@@ -941,19 +941,19 @@ reg64name(int reg, int hi)
 				if (off == 1)
 					off = T3 - T2;
 				break;
-			default: 
+			default:
 				idx = T4;
-		} 
+		}
 	} else if (reg >= DA0) {
 		idx = A0 + 2*(reg-DA0);
 	} else if (off == 0) {
 		idx = reg;
 	} else {
 		printf("bad reg64name: (%d) \n", reg);
-	//	user_stacktrace();
+		/* user_stacktrace(); */
 		return;
 	}
-		
+
 	printf("%s" , rnames[idx + off]);
 }
 
@@ -966,10 +966,10 @@ upput(NODE *p, int size)
 {
 
 	size /= SZCHAR;
-//fwalk(p, e2print, 0);
-//printf("upput p->n_op: 0x%x size %d", p->n_op, size);
-//printf("X");
-//return;
+	/* fwalk(p, e2print, 0); */
+	/* printf("upput p->n_op: 0x%x size %d", p->n_op, size); */
+	/* printf("X"); */
+	/* return; */
 
 
 	switch (p->n_op) {
@@ -1014,19 +1014,19 @@ adrput(FILE *io, NODE *p)
 			} else
 				printf(CONFMT, getlval(p));
 			return;
-	
+
 		case OREG:
 			printf("%d", (int)getlval(p));
 			printf("(%s)", rnames[regno(p)]);
 			return;
-	
+
 		case FCON:
 		case ICON:
 	#ifdef PCC_DEBUG
 			/* Sanitycheck for PIC, to catch adressable constants */
 			if (kflag && p->n_name[0] && 0) {
 				static int foo;
-	
+
 				if (foo++ == 0) {
 					printf("\nfailing...\n");
 					fwalk(p, e2print, 0);
@@ -1037,7 +1037,7 @@ adrput(FILE *io, NODE *p)
 			/* addressable value of the constant */
 			conput(io, p);
 			return;
-	
+
 		case REG:
 			switch (p->n_type) {
 				case LONGLONG:
@@ -1049,9 +1049,9 @@ adrput(FILE *io, NODE *p)
 					printf("%s", rnames[regno(p)]);
 				}
 			return;
-	
+
 		default:
-	//		user_stacktrace();
+		/* user_stacktrace(); */
 			comperr("illegal address, op %d, node %p", p->n_op, p);
 			return;
 
@@ -1080,7 +1080,7 @@ static int
 calc_args_size(NODE *p)
 {
 	int n = 0;
-        
+
         if (p->n_op == CM) {
                 n += calc_args_size(p->n_left);
                 n += calc_args_size(p->n_right);
@@ -1351,37 +1351,37 @@ p2arg_overflow(NODE* r)
   NODE* q = r;
   int sz, off = 0, last = 0, n_regs = 0, n_fregs = 0;
 
-	if (!r->n_left) 
+	if (!r->n_left)
 		last = 1;
-			
+
 	while (1)  {
-//printf("r: 0x%x, op: %d, n_left: 0x%x n_right: 0x%x last = %d\n", 
-//				r, r->n_op, r->n_left, r->n_right, last);
+		/* printf("r: 0x%x, op: %d, n_left: 0x%x n_right: 0x%x last = %d\n", */
+		/* r, r->n_op, r->n_left, r->n_right, last); */
 
 		if (q->n_op == STARG) {
-		//printf("STARG\n");
+		/* printf("STARG\n"); */
 			sz = attr_find(q->n_ap, ATTR_P2STRUCT)->iarg(0);
 			switch (sz) {
 				case 1:
 					n_regs += 1;
 					break;
-				case 2: 
+				case 2:
 					n_regs += 2;
 					break;
 				default:
 					n_regs += 1;
 			}
 		} else if (DEUNSIGN(q->n_type) == LONGLONG) {
-		//printf("LONGLONG\n");
+		/* printf("LONGLONG\n"); */
 						n_regs += 2;
 		} else if (q->n_type == DOUBLE || q->n_type == LDOUBLE) {
-		//printf("DOUBLE\n");
+		/* printf("DOUBLE\n"); */
 						n_fregs += 2;
 		} else if (q->n_type == FLOAT) {
-		//printf("FLOAT\n");
+		/* printf("FLOAT\n"); */
 						n_fregs += 1;
 		} else if (q->n_type > 0) {
-		//printf(">0\n");
+		/* printf(">0\n"); */
 						n_regs += 1;
 		}
 
@@ -1395,19 +1395,19 @@ p2arg_overflow(NODE* r)
 			last = 1;
 		}
 
-	} 
-	
-	if (n_fregs > NARGREGS) 
+	}
+
+	if (n_fregs > NARGREGS)
 		n_regs  += n_fregs - NARGREGS;
 
 	if (n_regs > NARGREGS) {
 			off += (n_regs - NARGREGS)*(SZINT/SZCHAR);
-	} 
+	}
 	if (n_fregs > NARGREGS) {
 			off += (n_fregs - NARGREGS)*(SZINT/SZCHAR);
-	}	
-	
-//printf("n_regs: %d, off: %d\n", n_regs, off);
+	}
+
+/* printf("n_regs: %d, off: %d\n", n_regs, off); */
 
 return off;
 
@@ -1429,12 +1429,12 @@ lastcall(NODE *p)
 
 	if (p->n_right == 0)
 		return;
-		
+
 	off  = p2arg_overflow(p->n_right->n_left);
-	p->n_qual = (off+15) & ~15; 
-	
-//printf("lastcall %d, 0x%x\n", p->n_qual, p->n_right->n_left);
-//fwalk(p, e2print, 0);
+	p->n_qual = (off+15) & ~15;
+
+	/* printf("lastcall %d, 0x%x\n", p->n_qual, p->n_right->n_left); */
+	/* fwalk(p, e2print, 0); */
 
 }
 

--- a/arch/sparc64/table.c
+++ b/arch/sparc64/table.c
@@ -2,11 +2,11 @@
 
 /*
  * Copyright (c) 2008 David Crawshaw <david@zentus.com>
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -25,7 +25,7 @@
 #define XSL(c)  NEEDS(NREG(c, 1), NSL(c))
 #define NAREG   NEEDS(NREG(A, 1))
 #define NBREG   NEEDS(NREG(B, 1))
-#define NCREG   NEEDS(NREG(C, 1))   
+#define NCREG   NEEDS(NREG(C, 1))
 #define NARL    NEEDS(NREG(A, 1), NSL(A), NSR(A))
 #define NBRL    NEEDS(NREG(B, 1), NSL(B), NSR(B))
 #define NCRL    NEEDS(NREG(C, 1), NSL(C), NSR(C))
@@ -170,7 +170,7 @@ struct optab table[] = {
 	SBREG,	TFLOAT,
 		NBREG,	RESC1,
 		"	ld [AL],A1	\t\t! int32/16/8 -> float\n"
-		"	fitos A1,A1\n", }, // XXX need 'lds', 'ldh', etc
+		"	fitos A1,A1\n", }, /* XXX need 'lds', 'ldh', etc */
 
 { SCONV,	INCREG,
 	SOREG,	T64|TUNSIGNED,
@@ -184,7 +184,7 @@ struct optab table[] = {
 	SCREG,	TDOUBLE,
 		NCREG,	RESC1,
 		"	ld [AL],A1	\t\t! int32/16/8 -> double\n"
-		"	fitod A1,A1\n", }, // XXX need 'lds' 'ldh' 'ld', etc.
+		"	fitod A1,A1\n", }, /* XXX need 'lds' 'ldh' 'ld', etc. */
 
 { SCONV,	INBREG,
 	SCREG,	TDOUBLE,
@@ -391,14 +391,14 @@ struct optab table[] = {
 	SAREG,	TSHORT|TUSHORT,
 		0,	RDEST,
         	"	sth AR,[AL]		! store (u)int16\n"
-		"	nop\n", },	
+		"	nop\n", },
 
 { ASSIGN,	FOREFF|INAREG,
 	SOREG,	TCHAR|TUCHAR,
 	SAREG,	TCHAR|TUCHAR,
 		0,	RDEST,
         	"	stb AR,[AL]		! store (u)int8\n"
-		"	nop\n", },	
+		"	nop\n", },
 
 { ASSIGN,	FOREFF|INAREG,
 	SOREG,	T64,

--- a/cc/cc/cc.c
+++ b/cc/cc/cc.c
@@ -59,7 +59,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -1378,7 +1378,7 @@ preprocess_input(char *input, char *output, int dodep)
 	strlist_append_list(&args, &preprocessor_flags);
 	if (ascpp) {
 		strlist_append(&args, "-A");
-		strlist_append(&args, "-D__ASSEMBLER__"); 
+		strlist_append(&args, "-D__ASSEMBLER__");
 	}
 	STRLIST_FOREACH(s, &includes) {
 		strlist_append(&args, "-i");
@@ -1445,7 +1445,7 @@ static char *
 select_linker(char *name)
 {
 	static char ld_name[8];
- 
+
 	/* Short names first.  */
 	if (strcmp(name, "bfd") == 0 ||
 	    strcmp(name, "gold") == 0 ||
@@ -1453,11 +1453,11 @@ select_linker(char *name)
 		snprintf(ld_name, sizeof ld_name, "ld.%s", name);
 		return ld_name;
 	}
- 
+
 	/* Must be absolute path otherwise.  */
 	if (name[0] != '/')
 		return LINKER;
- 
+
 	return name;
 }
 
@@ -1543,14 +1543,14 @@ strlist_exec(struct strlist *l)
 	si.cb = sizeof(STARTUPINFO);
 	ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
 
-	ok = CreateProcess(NULL,  // the executable program
-		cmd,   // the command line arguments
-		NULL,       // ignored
-		NULL,       // ignored
-		TRUE,       // inherit handles
+	ok = CreateProcess(NULL,  /* the executable program */
+		cmd,   /* the command line arguments */
+		NULL,       /* ignored */
+		NULL,       /* ignored */
+		TRUE,       /* inherit handles */
 		HIGH_PRIORITY_CLASS,
-		NULL,       // ignored
-		NULL,       // ignored
+		NULL,       /* ignored */
+		NULL,       /* ignored */
 		&si,
 		&pi);
 
@@ -1924,7 +1924,7 @@ setup_cpp_flags(void)
 		char buf[100]; /* larger than needed */
 		time_t t = time(NULL);
 		char *n = ctime(&t);
-	
+
 		n[19] = 0;
 		snprintf(buf, sizeof buf, "-D__TIME__=\"%s\"", n+11);
 		strlist_prepend(&preprocessor_flags, xstrdup(buf));

--- a/cc/ccom/complex.c
+++ b/cc/ccom/complex.c
@@ -280,17 +280,17 @@ cxop(int op, P1ND *l, P1ND *r)
 		return p;
 
 	case UMINUS:
-		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, real), 
+		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, real),
 		    buildtree(op, real_l, NULL)));
-		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, imag), 
+		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, imag),
 		    buildtree(op, imag_l, NULL)));
 		break;
 
 	case PLUS:
 	case MINUS:
-		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, real), 
+		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, real),
 		    buildtree(op, real_l, real_r)));
-		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, imag), 
+		p = comop(p, buildtree(ASSIGN, structref(p1tcopy(q), DOT, imag),
 		    buildtree(op, imag_l, imag_r)));
 		break;
 
@@ -470,7 +470,7 @@ imret(P1ND *p, P1ND *q)
 		} else
 			p = bcon(0);
 	}
-		
+
 	return p;
 }
 
@@ -511,7 +511,7 @@ cxcast(P1ND *p1, P1ND *p2)
 }
 
 void
-//cxargfixup(P1ND *a, TWORD dt, struct attr *ap)
+/* cxargfixup(P1ND *a, TWORD dt, struct attr *ap) - old signature */
 cxargfixup(P1ND *a, struct tdef *td)
 {
 	P1ND *p;

--- a/cc/ccom/inline.c
+++ b/cc/ccom/inline.c
@@ -34,7 +34,7 @@
  * A function found with the keyword "inline" is always saved.
  * If it also has the keyword "extern" it is written out thereafter.
  * If it has the keyword "static" it will be written out if it is referenced.
- * inlining will only be done if -xinline is given, and only if it is 
+ * inlining will only be done if -xinline is given, and only if it is
  * possible to inline the function.
  */
 static void printip(struct interpass *pole);
@@ -44,7 +44,7 @@ struct ntds {
 	TWORD type;
 	union dimfun *df;
 	struct ssdesc *ss;
-//	struct attr *attr;
+	/* struct attr *attr; */
 };
 
 /*
@@ -228,15 +228,15 @@ inline_start(struct symtab *sp, int class)
  *
  * Gcc inline syntax is a mess, see matrix below on emitting functions:
  *		    without extern
- *	-std=		-	gnu89	gnu99	
+ *	-std=		-	gnu89	gnu99
  *	gcc 3.3.5:	ja	ja	ja
  *	gcc 4.1.3:	ja	ja	ja
- *	gcc 4.3.1	ja	ja	nej	
- * 
+ *	gcc 4.3.1	ja	ja	nej
+ *
  *		     with extern
  *	gcc 3.3.5:	nej	nej	nej
  *	gcc 4.1.3:	nej	nej	nej
- *	gcc 4.3.1	nej	nej	ja	
+ *	gcc 4.3.1	nej	nej	ja
  *
  * The above is only true if extern is given on the same line as the
  * function declaration.  If given as a separate definition it do not count.
@@ -463,7 +463,7 @@ rtmps(NODE *p, void *arg)
 
 /*
  * Inline a function. Returns the return value.
- * There are two major things that must be converted when 
+ * There are two major things that must be converted when
  * inlining a function:
  * - Label numbers must be updated with an offset.
  * - The stack block must be relocated (add to REG or OREG).
@@ -556,7 +556,7 @@ inlinetree(struct symtab *sp, P1ND *f, P1ND *ap)
 		if (ipl->type == IP_DEFLAB)
 			break;
 	}
-		
+
 	/* So, walk over all statements and emit them */
 	for (ip = ipf; ip != ipl; ip = DLIST_NEXT(ip, qelem)) {
 		switch (ip->type) {

--- a/cc/ccom/main.c
+++ b/cc/ccom/main.c
@@ -137,7 +137,7 @@ main(int argc, char *argv[])
 	int sdflag;
 #endif
 
-//kflag = 1;
+/* kflag = 1; */
 #ifdef TIMING
 	struct timeval t1, t2;
 

--- a/cc/ccom/optim.c
+++ b/cc/ccom/optim.c
@@ -29,7 +29,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -85,9 +85,9 @@ fortarg(NODE *p)
 }
 
 	/* mapping relationals when the sides are reversed */
-// short revrel[] ={ EQ, NE, GE, GT, LE, LT, UGE, UGT, ULE, ULT };
+	/* short revrel[] ={ EQ, NE, GE, GT, LE, LT, UGE, UGT, ULE, ULT }; */
 
-/*
+	/*
  * local optimizations, most of which are probably
  * machine independent
  */
@@ -245,7 +245,7 @@ again:	o = p->n_op;
 			/* avoid larger shifts than type size */
 			if (RV(p) >= sz)
 				werror("shift larger than type");
-			if (RV(p) == 0)  
+			if (RV(p) == 0)
 				p = zapleft(p);
 		}
 		break;
@@ -400,12 +400,12 @@ again:	o = p->n_op;
 	case EQ:
 	case NE:
 	case LT:
-//	case LE:
-//	case GT:
+	/* case LE: */
+	/* case GT: */
 	case GE:
 	case ULT:
-//	case ULE:
-//	case UGT:
+	/* case ULE: */
+	/* case UGT: */
 	case UGE:
 		if (LCON(p) && RCON(p) &&
 		    !ISPTR(p->n_left->n_type) && !ISPTR(p->n_right->n_type)) {
@@ -443,7 +443,7 @@ again:	o = p->n_op;
 			}
 		}
 		break;
-				
+
 
 #ifdef notyet
 	case ASSIGN:

--- a/cc/ccom/params.c
+++ b/cc/ccom/params.c
@@ -106,9 +106,9 @@ fun_enter(struct symtab *sp, struct symtab **spp, int nargs)
 	for (i = 0; i < cs->nargs; i++) {
 		rp = &cs->av[i];
 		sp = spp[i];
-		//sz = (int)tsize(rp->type, rp->df, rp->ss);
+		/* sz = (int)tsize(rp->type, rp->df, rp->ss); */
 		if (rp->flags & AV_STREG) {
-			// st = (int)tsize(off, 0, 0);
+			/* st = (int)tsize(off, 0, 0); */
 			cerror("AV_STREG");
 		} else if (rp->flags & AV_REG2) {
 			cerror("AV_REG2");
@@ -265,7 +265,7 @@ fun_call(P1ND *p)
 		q = np[i];
 
 		/*
-		 * The ABI may declare that a parameter shall end up in 
+		 * The ABI may declare that a parameter shall end up in
 		 * multiple locations.
 		 * XXX use COMOP.
 		 */
@@ -486,7 +486,7 @@ if (pdebug) printf("pr_hasell: dsym %d\n", dsym);
 }
 
 /*
- * Extract the important parts of arguments and put away them for 
+ * Extract the important parts of arguments and put away them for
  * prototype checking.
  * Return index pointer for this prototype argument list.
  */

--- a/cc/ccom/pass1.h
+++ b/cc/ccom/pass1.h
@@ -29,7 +29,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -70,7 +70,7 @@ typedef unsigned int bittype; /* XXX - for basicblock */
 #define TYPEDEF		13
 /* #define FORTRAN		14 */
 #define ENAME		15
-//#define MOE		16
+/* #define MOE		16 */
 #define CCONST		16
 /* #define UFORTRAN 	17 */
 #define USTATIC		18
@@ -123,11 +123,11 @@ struct gcc_attr_pack;
  *	- The dimension/function pointer
  *	- The size/struct description table pointer.
  *
- * The dimfun pointer points into an array of "union dimfun", which is the 
+ * The dimfun pointer points into an array of "union dimfun", which is the
  * same size as the number of ARY/FTN in the type word.  See below.
  *
  * The size/struct description member is only used if needed, unless it is
- * a struct/union when it always is avaliable.  It has three initial 
+ * a struct/union when it always is avaliable.  It has three initial
  * elements, thereafter followed by parameters that are allocated if needed.
  *
  * Note that some type/variable attributes may be stored in this struct.
@@ -189,8 +189,8 @@ struct	symtab {
 /* compat */
 #define stype td->type
 #define squal td->qual
-#define sdf td->df    
-#define sss td->ss    
+#define sdf td->df
+#define sss td->ss
 
 /*
  * External definitions
@@ -266,7 +266,7 @@ void defalign(int al);
 void symdirec(struct symtab *sp);
 
 /*
- * Tree struct for pass1.  
+ * Tree struct for pass1.
  */
 struct flt;
 
@@ -386,7 +386,7 @@ void cbranch(P1ND *, P1ND *);
 void extdec(struct symtab *);
 void defzero(struct symtab *);
 int falloc(struct symtab *, int, P1ND *);
-TWORD ctype(TWORD);  
+TWORD ctype(TWORD);
 void inval(CONSZ, int, P1ND *);
 int ninval(CONSZ, int, P1ND *);
 void infld(CONSZ, int, CONSZ);
@@ -502,8 +502,8 @@ P1ND *p1tcopy(P1ND *);
 struct flt {
 	struct softfloat sf;
 	TWORD t;
-};	
-typedef struct flt FLT;	
+};
+typedef struct flt FLT;
 #define	sfallo()		stmtalloc(sizeof(struct softfloat))
 
 struct lexint {
@@ -628,7 +628,7 @@ enum {	ATTR_FIRST = ATTR_MI_MAX + 1,
  */
 #define amlist  aa[0].varg
 #define amsize  aa[1].iarg
-// #define	strattr(x)	(attr_find(x, ATTR_STRUCT))
+/* #define	strattr(x)	(attr_find(x, ATTR_STRUCT)) */
 #define	strattr(x)	((x)->ss)
 
 void gcc_init(void);

--- a/cc/ccom/pftn.c
+++ b/cc/ccom/pftn.c
@@ -53,7 +53,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -488,7 +488,7 @@ defid2(NODE *q, int class, char *astr)
 		if (q->n_type != FARG)
 			oalloc(p, &argoff);
 		break;
-		
+
 	case STATIC:
 	case EXTDEF:
 	case EXTERN:
@@ -819,7 +819,7 @@ enumdcl(struct symtab *sp)
 		t = ctype(INT);
 #endif
 #endif
-	
+
 	if (sp)
 		sp->stype = t;
 	p = mkty(t, 0, 0);
@@ -965,10 +965,10 @@ soumemb(NODE *n, char *name, int class)
 	struct symtab *sp, *lsp;
 	int incomp, tsz, al;
 	TWORD t;
- 
+
 	if (rpole == NULL)
 		cerror("soumemb");
- 
+
 #ifdef PCC_DEBUG
         if (ddebug) {
 		printf("soumemb %s\n", name);
@@ -1253,7 +1253,7 @@ instring(struct symtab *sp)
 				(void)esccon(&s);
 			else
 				s++;
-	
+
 			if (s - str > 60) {
 				fwrite(str, 1, s - str, stdout);
 				printf("\"\n" PRTPREF "\t.ascii \"");
@@ -1289,7 +1289,7 @@ upoff(int size, int alignment, int *poff)
 /*
  * allocate p with offset *poff, and update *poff.
  * This routine is used to create stack reference for arguments and automatics.
- * poff is always increasing even if the stack goes downwards, hence 
+ * poff is always increasing even if the stack goes downwards, hence
  * the off must must be calculated before/after the increase/decrease
  * of the stack pointer.
  */
@@ -1670,7 +1670,7 @@ typwalk(NODE *p, void *arg)
 		break;
 
 	case QUALIFIER:
-		if (p->n_qual == 0 && 
+		if (p->n_qual == 0 &&
 		    ((tc->saved && !ISPTR(tc->saved->n_type)) ||
 		    (tc->saved == 0)))
 			uerror("invalid use of 'restrict'");
@@ -1848,7 +1848,7 @@ typenode(NODE *p)
 #endif
 
 	if (tc.align) {
-		if (q->pss == NULL) 
+		if (q->pss == NULL)
 			q->pss = SEDESC();
 		if (tc.align > talign(q->n_type, q->pss)/SZCHAR)
 			q->pss->al = tc.align * tc.align;
@@ -1989,11 +1989,11 @@ tymerge(NODE *typ, NODE *idp)
 		idp->n_df = memcpy(a, dfs, sizeof(union dimfun) * numdfs);
 	} else
 		idp->n_df = NULL;
-//{int i; for (i = 0; i < numdfs; i++)printf("tym%d: %p\n", i, &idp->n_df[i]); }
+	/* {int i; for (i = 0; i < numdfs; i++)printf("tym%d: %p\n", i, &idp->n_df[i]); } */
 
 	/* now idp is a single node: fix up type */
 	idp->n_type = ctype(idp->n_type);
-	
+
 	if (idp->n_op != NAME)
 		p1tfree(idp->n_left);
 	idp->n_op = NAME;

--- a/cc/ccom/trees.c
+++ b/cc/ccom/trees.c
@@ -56,7 +56,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 /*
@@ -154,7 +154,7 @@ static char *tnames[] = {
 	*/
 
 /* negatives of relationals */
-//int p1negrel[] = { NE, EQ, GT, GE, LT, LE, UGT, UGE, ULT, ULE };
+/* int p1negrel[] = { NE, EQ, GT, GE, LT, LE, UGT, UGE, ULT, ULE }; */
 
 /* Have some defaults for most common targets */
 #ifndef WORD_ADDRESSED
@@ -364,15 +364,15 @@ buildtree(int o, P1ND *l, P1ND *r)
 			q = cstknode(ll->n_type, ll->n_df, ll->pss);
 			l->n_left = p1tcopy(q);
 			q = buildtree(ASSIGN, q, ll);
-		} else 
+		} else
 			q = bcon(0); /* No side effects */
 
 		/*
 		 * Modify the trees so that the compound op is rewritten.
 		 */
 		/* avoid casting of LHS */
-		if ((cdope(o) & SIMPFLG) && ISINTEGER(l->n_type) && 
-		    l->n_type != BOOL) 
+		if ((cdope(o) & SIMPFLG) && ISINTEGER(l->n_type) &&
+		    l->n_type != BOOL)
 			r = ccast(r, l->n_type, l->n_qual, l->n_df, l->pss);
 
 		r = buildtree(UNASG o, p1tcopy(l), r);
@@ -391,7 +391,7 @@ buildtree(int o, P1ND *l, P1ND *r)
 			q = cstknode(ll->n_type, ll->n_df, ll->pss);
 			l->n_left = p1tcopy(q);
 			q = buildtree(ASSIGN, q, ll);
-		} else 
+		} else
 			q = bcon(0); /* No side effects */
 
 		/* Boolean has special syntax. */
@@ -661,14 +661,14 @@ runtime:
 
 	}
 
-/*                      
+/*
  * Rewrite ++/-- to (t=p, p++, t) ops on types that do not act act as usual.
  */
 static P1ND *
 rewincop(P1ND *p1, P1ND *p2, int op)
 {
 	P1ND *t, *r;
-		
+
 	t = cstknode(p1->n_type, p1->n_df, p1->pss);
 	r = buildtree(ASSIGN, p1tcopy(t), p1tcopy(p1));
 	r = buildtree(COMOP, r, buildtree(op, p1, eve(p2)));
@@ -725,7 +725,7 @@ nametree(struct symtab *sp)
 #ifndef NO_C_BUILTINS
 	if (sp->sname[0] == '_' && strncmp(sp->sname, "__builtin_", 10) == 0)
 		return p;  /* do not touch builtins here */
-	
+
 #endif
 
 	if (sp->sflags & STNODE) {
@@ -786,7 +786,7 @@ ccast(P1ND *p, TWORD t, TWORD u, union dimfun *df, struct ssdesc *ss)
 {
 	P1ND *q;
 
-	/* let buildtree do typechecking (and casting) */ 
+	/* let buildtree do typechecking (and casting) */
 	q = block(NAME, NULL, NULL, t, df, ss);
 	p = buildtree(ASSIGN, q, p);
 	if (ISSOU(t)) {
@@ -826,8 +826,8 @@ concast(P1ND *p, TWORD t)
 	if (((p->n_type & TMASK) && t != BOOL) || (t & TMASK)) /* no pointers */
 		return 0;
 
-//printf("concast till %d\n", t);
-//p1fwalk(p, eprint, 0);
+	/* printf("concast till %d\n", t); */
+	/* p1fwalk(p, eprint, 0); */
 
 #define	TYPMSK(y) ((((1LL << (y-1))-1) << 1) | 1)
 	if (p->n_op == ICON) {
@@ -861,7 +861,7 @@ concast(P1ND *p, TWORD t)
 		}
 	}
 	p->n_type = t;
-//fwalk(p, eprint, 0);
+	/* fwalk(p, eprint, 0); */
 	return 1;
 }
 
@@ -1654,7 +1654,7 @@ makety(P1ND *p, struct tdef *td)
 	return clocal(p);
 }
 
-P1ND *  
+P1ND *
 blk(int o, P1ND *l, P1ND *r, struct tdef *td)
 {
 	register P1ND *p;
@@ -1700,18 +1700,18 @@ icons(P1ND *p)
 	return(val);
 }
 
-/* 
+/*
  * the intent of this table is to examine the
  * operators, and to check them for
  * correctness.
- * 
+ *
  * The table is searched for the op and the
  * modified type (where this is one of the
  * types INT (includes char and short), LONG,
  * DOUBLE (includes FLOAT), and POINTER
- * 
+ *
  * The default action is to make the node type integer
- * 
+ *
  * The actions taken include:
  * 	PUN	  check for puns
  * 	CVTL	  convert the left operand
@@ -1725,7 +1725,7 @@ icons(P1ND *p)
  * 	NCVT	  do not convert the operands
  * 	OTHER	  handled by code
  * 	NCVTR	  convert the left operand, not the right...
- * 
+ *
  */
 
 # define MINT 01	/* integer */
@@ -1980,7 +1980,7 @@ doszof(P1ND *p)
 		df++;
 		ty = DECREF(ty);
 	}
-	rv = buildtree(MUL, rv, 
+	rv = buildtree(MUL, rv,
 	    xbcon(tsize(ty, p->n_df, p->pss)/SZCHAR, NULL, INTPTR));
 	p1tfree(p);
 	return rv;
@@ -2027,7 +2027,7 @@ eprint(P1ND *p, int down, int *a, int *b)
 # endif
 
 /*
- * Emit everything that should be emitted on the left side 
+ * Emit everything that should be emitted on the left side
  * of a comma operator, and remove the operator.
  * Do not traverse through QUEST, ANDAND and OROR.
  * Enable this for all targets when stable enough.
@@ -2134,13 +2134,13 @@ andorbr(P1ND *p, int _true, int _false)
 	int o, lab;
 
 	lab = -1;
-	switch (o = p->n_op) { 
+	switch (o = p->n_op) {
 	case EQ:
 	case NE:
 		/*
 		 * Remove redundant EQ/NE nodes.
 		 */
-		while (((o = p->n_left->n_op) == EQ || o == NE) && 
+		while (((o = p->n_left->n_op) == EQ || o == NE) &&
 		    p->n_right->n_op == ICON) {
 			o = p->n_op;
 			q = p->n_left;
@@ -2158,7 +2158,7 @@ andorbr(P1ND *p, int _true, int _false)
 					p->n_op = EQ; /* toggla */
 			} else
 				break; /* XXX - should always be false */
-			
+
 		}
 		/* FALLTHROUGH */
 	case LE:
@@ -2495,7 +2495,7 @@ rdualfld(P1ND *p, TWORD t, TWORD ct, int off, int fsz)
 }
 
 /*
- * Write val to a (unaligned) bitfield with length fsz positioned off bits  
+ * Write val to a (unaligned) bitfield with length fsz positioned off bits
  * from d. Bitfield type is t, and type to use when writing is ct.
  * neither f nor d should have any side effects if copied.
  * Multiples of ct are supposed to be written without problems.
@@ -2503,31 +2503,31 @@ rdualfld(P1ND *p, TWORD t, TWORD ct, int off, int fsz)
  */
 static P1ND *
 wrualfld(P1ND *val, P1ND *d, TWORD t, TWORD ct, int off, int fsz)
-{ 
+{
 	P1ND *p, *q, *r, *rn, *s;
 	int ctsz, t2f, inbits;
- 
+
 	ctsz = (int)tsize(ct, 0, 0);
-  
+
 	ct = ENUNSIGN(ct);
 	d = makety(d, mkqtyp(PTR|ct));
 
 	for (t2f = 0; off >= ctsz; t2f++, off -= ctsz)
 		;
- 
+
 	if (off + fsz <= ctsz) {
 		r = tempnode(0, ct, 0, 0);
 
 		/* only one operation needed */
-		d = buildtree(UMUL, buildtree(PLUS, d, bcon(t2f)), 0);	
-		p = p1tcopy(d); 
+		d = buildtree(UMUL, buildtree(PLUS, d, bcon(t2f)), 0);
+		p = p1tcopy(d);
 		p = TYPAND(p, xbcon(~(SZMASK(fsz) << off), 0, ct), ct);
 
 		val = makety(val, mkqtyp(ct));
 		q = TYPAND(val, xbcon(SZMASK(fsz), 0, ct), ct);
 		q = buildtree(ASSIGN, p1tcopy(r), q);
 
-		q = TYPLS(q, bcon(off), ct);   
+		q = TYPLS(q, bcon(off), ct);
 		p = TYPOR(p, q, ct);
 		p = makety(p, mkqtyp(t));
 		rn = buildtree(ASSIGN, d, p);
@@ -2539,8 +2539,8 @@ wrualfld(P1ND *val, P1ND *d, TWORD t, TWORD ct, int off, int fsz)
 		r = buildtree(UMUL, buildtree(PLUS, p1tcopy(d), bcon(t2f)), 0);
 		p = p1tcopy(r);
 		p = TYPAND(p, xbcon(SZMASK(off), 0, ct), ct);
-		q = p1tcopy(val); 
-		q = TYPLS(q, bcon(off), t);  
+		q = p1tcopy(val);
+		q = TYPLS(q, bcon(off), t);
 		q = makety(q, mkqtyp(ct));
 		p = TYPOR(p, q, ct);
 		rn = buildtree(ASSIGN, r, p);
@@ -2654,7 +2654,7 @@ rmfldops(P1ND *p)
 			q = q->n_left;
 			t1 = tempnode(0, q->n_left->n_type, 0, 0);
 			r = buildtree(ASSIGN, p1tcopy(t1), q->n_left);
-			
+
 			bt = bt ? blk(COMOP, bt, r, tdint) : r;
 			q->n_left = t1;
 		}
@@ -2740,11 +2740,11 @@ ecomp(P1ND *p)
 
 
 #ifdef PASS1
-/* 
+/*
  * Print out full tree.
  * Nodes are already converted to pass2 style.
  */
-static void	
+static void
 p2print(NODE *p)
 {
 	struct attr *ap;
@@ -2830,7 +2830,7 @@ pass2_compile(struct interpass *ip)
 			printf("$ ");
 			while (*s != '\0') {
 				putchar(*s);
-				if (*s++ == '\n') 
+				if (*s++ == '\n')
 					printf("$ ");
 			}
 			printf("\n");
@@ -2838,7 +2838,7 @@ pass2_compile(struct interpass *ip)
 		break;
 	case IP_EPILOG:
 		ipp = (struct interpass_prolog *)ip;
-		printf("%% %d %d %d %d %s", 
+		printf("%% %d %d %d %d %s",
 		    ipp->ipp_autos, ip->ip_lbl, ipp->ip_tmpnum,
 		    ipp->ip_lblnum, ipp->ipp_name);
 		if (ipp->ip_labels[0]) {
@@ -2989,7 +2989,7 @@ delvoid(P1ND *p, void *arg)
 		} else
 			p->n_type = (p->n_type & ~BTMASK) | BOOL_TYPE;
 	}
-		
+
 }
 
 #ifndef NEWPARAMS
@@ -3079,7 +3079,7 @@ pprop(P1ND *p, TWORD t, struct ssdesc *ss)
 			if (ISPTR(p->n_right->n_type))
 				break; /* change both */
 			p->n_left = pprop(p->n_left, t, ss);
-		} else 
+		} else
 			p->n_right = pprop(p->n_right, t, ss);
 		return p;
 
@@ -3167,12 +3167,12 @@ optloop(P1ND *p)
 }
 
 void
-ecode(P1ND *p)	
+ecode(P1ND *p)
 {
 	NODE *r;
 	/* walk the tree and write out the nodes.. */
 
-	if (nerrors)	
+	if (nerrors)
 		return;
 
 #ifdef GCC_COMPAT
@@ -3196,8 +3196,8 @@ ecode(P1ND *p)
 	p1walkf(p, delvoid, 0);
 #ifdef PCC_DEBUG
 	if (xdebug) {
-		printf("Fulltree:\n"); 
-		p1fwalk(p, eprint, 0); 
+		printf("Fulltree:\n");
+		p1fwalk(p, eprint, 0);
 	}
 #endif
 	if (p->n_op == LABEL) {
@@ -3404,12 +3404,12 @@ cdope(int op)
 	return 0; /* XXX gcc */
 }
 
-/* 
+/*
  * make a fresh copy of p
  */
 P1ND *
-p1tcopy(P1ND *p) 
-{  
+p1tcopy(P1ND *p)
+{
 	P1ND *q;
 
 	q = p1alloc();
@@ -3419,7 +3419,7 @@ p1tcopy(P1ND *p)
 	case BITYPE:
 		q->n_right = p1tcopy(p->n_right);
 		/* FALLTHROUGH */
-	case UTYPE: 
+	case UTYPE:
 		q->n_left = p1tcopy(p->n_left);
 	}
 
@@ -3442,7 +3442,7 @@ p1nfree(P1ND *p)
 
 	if (p == NULL)
 		cerror("freeing blank node!");
-		
+
 	l = p->n_left;
 	if (p->n_op == FREE)
 		cerror("freeing FREE node", p);

--- a/cc/cpp/token.c
+++ b/cc/cpp/token.c
@@ -226,7 +226,7 @@ packbuf(void)
 				;
 			if (--p >= pend)
 				return;
-	
+
 			switch (*p) {
 			case '?':
 				if (p[1] == '?'&& chktg2(p[2]))
@@ -261,7 +261,7 @@ psave:				if (pend-p < 3) {
 			p++;
 		}
 slow:		q = p;
-	} 
+	}
 
 /* need to pack, so we must write as well */
 
@@ -325,7 +325,7 @@ slow:		q = p;
 
 	}
 
-psave2:	
+psave2:
 	/* Save for future use */
 #ifdef PCC_DEBUG
 	if (pend-p > 9)
@@ -788,7 +788,7 @@ run:			while ((ch = qcchar()) == '\t' || ch == ' ')
 					warning("unterminated literal");
 					p--;
 					break;
-				} else if (c2 == ch) 
+				} else if (c2 == ch)
 					break;
 				p++;
 			}
@@ -1010,11 +1010,11 @@ ident:		if (ISID0(t) == 0)
 		}
 		break;
 	}
-//fprintf(stderr, "uulex1: ch '%c' %d val=%lld '%s'\n", ch, ch, yynode.nd_val, inp);
+/* fprintf(stderr, "uulex1: ch '%c' %d val=%lld '%s'\n", ch, ch, yynode.nd_val, inp); */
 	return ch;
 
 pb:	*--inp = c2;
-//fprintf(stderr, "uulex2: ch '%c' %d val=%lld '%s'\n", ch, ch, yynode.nd_val, inp);
+/* fprintf(stderr, "uulex2: ch '%c' %d val=%lld '%s'\n", ch, ch, yynode.nd_val, inp); */
 	return ch;
 }
 

--- a/cc/cxxcom/cxxcode.c
+++ b/cc/cxxcom/cxxcode.c
@@ -87,7 +87,7 @@ callftn(char *n, ...)
 				a = buildtree(CM, a, b);
 		} while (b != NULL);
 	}
-	
+
 	p = doacall(sp, nametree(sp), a, 0);
 	va_end(ap);
 	return p;
@@ -111,7 +111,7 @@ cxx_new(NODE *p)
 	}
 	if (p->n_op != TYPE)
 		uerror("new used illegally");
-	t1 = buildtree(MUL, t1, 
+	t1 = buildtree(MUL, t1,
 	    xbcon(tsize(p->n_type, p->n_df, p->n_ap)/SZCHAR, NULL, INTPTR));
 	tfree(q);
 	return callftn(decoratename(NULL, nw), t1, NULL);
@@ -127,58 +127,58 @@ cxx_delete(NODE *p, int del)
 }
 
 /*
-  <operator-name> ::= nw	# new           
+  <operator-name> ::= nw	# new
 		  ::= na	# new[]
-		  ::= dl	# delete        
-		  ::= da	# delete[]      
+		  ::= dl	# delete
+		  ::= da	# delete[]
 		  ::= ps        # + (unary)
-		  ::= ng	# - (unary)     
-		  ::= ad	# & (unary)     
-		  ::= de	# * (unary)     
-		  ::= co	# ~             
-		  ::= pl	# +             
-		  ::= mi	# -             
-		  ::= ml	# *             
-		  ::= dv	# /             
-		  ::= rm	# %             
-		  ::= an	# &             
-		  ::= or	# |             
-		  ::= eo	# ^             
-		  ::= aS	# =             
-		  ::= pL	# +=            
-		  ::= mI	# -=            
-		  ::= mL	# *=            
-		  ::= dV	# /=            
-		  ::= rM	# %=            
-		  ::= aN	# &=            
-		  ::= oR	# |=            
-		  ::= eO	# ^=            
-		  ::= ls	# <<            
-		  ::= rs	# >>            
-		  ::= lS	# <<=           
-		  ::= rS	# >>=           
-		  ::= eq	# ==            
-		  ::= ne	# !=            
-		  ::= lt	# <             
-		  ::= gt	# >             
-		  ::= le	# <=            
-		  ::= ge	# >=            
-		  ::= nt	# !             
-		  ::= aa	# &&            
-		  ::= oo	# ||            
+		  ::= ng	# - (unary)
+		  ::= ad	# & (unary)
+		  ::= de	# * (unary)
+		  ::= co	# ~
+		  ::= pl	# +
+		  ::= mi	# -
+		  ::= ml	# *
+		  ::= dv	# /
+		  ::= rm	# %
+		  ::= an	# &
+		  ::= or	# |
+		  ::= eo	# ^
+		  ::= aS	# =
+		  ::= pL	# +=
+		  ::= mI	# -=
+		  ::= mL	# *=
+		  ::= dV	# /=
+		  ::= rM	# %=
+		  ::= aN	# &=
+		  ::= oR	# |=
+		  ::= eO	# ^=
+		  ::= ls	# <<
+		  ::= rs	# >>
+		  ::= lS	# <<=
+		  ::= rS	# >>=
+		  ::= eq	# ==
+		  ::= ne	# !=
+		  ::= lt	# <
+		  ::= gt	# >
+		  ::= le	# <=
+		  ::= ge	# >=
+		  ::= nt	# !
+		  ::= aa	# &&
+		  ::= oo	# ||
 		  ::= pp	# ++ (postfix in <expression> context)
-		  ::= mm	# -- (postfix in <expression> context)           
-		  ::= cm	# ,             
-		  ::= pm	# ->*           
-		  ::= pt	# ->            
-		  ::= cl	# ()            
-		  ::= ix	# []            
-		  ::= qu	# ?             
+		  ::= mm	# -- (postfix in <expression> context)
+		  ::= cm	# ,
+		  ::= pm	# ->*
+		  ::= pt	# ->
+		  ::= cl	# ()
+		  ::= ix	# []
+		  ::= qu	# ?
 		  ::= st	# sizeof (a type)
 		  ::= sz	# sizeof (an expression)
                   ::= at        # alignof (a type)
                   ::= az        # alignof (an expression)
-		  ::= cv <type>	# (cast)        
+		  ::= cv <type>	# (cast)
 		  ::= v <digit> <source-name>	# vendor extended operator
 */
 
@@ -274,7 +274,7 @@ static void
 pshargs(union arglist *al)
 {
 	TWORD t;
-	
+
 
 	for (; al->type != TNULL; al++) {
 		t = al->type;
@@ -432,7 +432,7 @@ char *symclass[] = { "NORMAL", "CLASS", "LABEL", "MOS", "STRING" };
  * may not be correct.
  * If no symbol is found, return a new symtab entry.
  * p should be a NAME after this with n_sp filled in accordingly.
- * It's the responsibility of the declaration routine to add it to 
+ * It's the responsibility of the declaration routine to add it to
  * the symbol table.
  * nfree() will be called on p after this function.
  */
@@ -499,7 +499,7 @@ cxxlookup(NODE *p, int flags)
 			}
 		}
 	}
-	
+
 	/* make top node a NAME */
 	if (q->n_op != NAME) {
 		tfree(q->n_left);
@@ -554,10 +554,10 @@ cxxdclstr(char *n)
 		sp = sfind(n, sp->snext);
 	if (sp == 0)
 		sp = getsymtab(n, STAGNAME);
-//	else
-//		uerror("class/namespace redefined");
-//	INSSYM(sp);
-//	nscur = sp;
+	/* else
+		uerror("class/namespace redefined");
+	INSSYM(sp);
+	nscur = sp; */
 
 if (cppdebug)printf("declaring2 struct %s %p nscur %s\n", n, sp, nscur->sname);
 	return sp;
@@ -567,7 +567,7 @@ if (cppdebug)printf("declaring2 struct %s %p nscur %s\n", n, sp, nscur->sname);
 static void
 symwalk(struct symtab *sp, int indent)
 {
-	int i; 
+	int i;
 
 	while (sp) {
 		for (i = 0; i < indent; i++)
@@ -756,7 +756,7 @@ undecl:
 }
 
 /*
- * Search for correct matching function in a struct depending on 
+ * Search for correct matching function in a struct depending on
  * argument list a.  Return a call node for this function.
  * Do not touch neither f nor a.
  * return a name tree suitable for a function call.

--- a/cc/cxxcom/pftn.c
+++ b/cc/cxxcom/pftn.c
@@ -53,7 +53,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -93,7 +93,7 @@ struct rstack {
 	int	rsou;
 	int	rstr;
 	struct	symtab *rsym;
-//	struct	symtab *rb;
+	/* struct	symtab *rb; */
 	struct	attr *ap;
 	int	flags;
 #define	LASTELM	1
@@ -429,7 +429,7 @@ defid(NODE *q, int class)
 		if (q->n_type != FARG)
 			oalloc(p, &argoff);
 		break;
-		
+
 	case STATIC:
 	case EXTDEF:
 	case EXTERN:
@@ -803,7 +803,7 @@ enumdcl(struct symtab *sp)
 		t = ctype(INT);
 #endif
 #endif
-	
+
 	if (sp)
 		sp->stype = t;
 	p = mkty(t, 0, 0);
@@ -891,7 +891,7 @@ bstruct(char *name, int soru, NODE *gp)
 	r = tmpcalloc(sizeof(struct rstack));
 	r->rsou = soru;
 	r->rsym = sp;
-//	r->rb = NULL;
+	/* r->rb = NULL; */
 	r->ap = gap;
 	r->rnext = rpole;
 	rpole = r;
@@ -915,7 +915,7 @@ dclstruct(struct rstack *r)
 
 	apb = attr_find(r->ap, ATTR_ALIGNED);
 	aps = attr_find(r->ap, ATTR_STRUCT);
-//	aps->amlist = r->rb;
+	/* aps->amlist = r->rb; */
 	aps->amlist = nscur->sup;
 
 #ifdef ALSTRUCT
@@ -989,10 +989,10 @@ soumemb(NODE *n, char *name, int class)
 	struct symtab *sp, *lsp;
 	int incomp, tsz, al;
 	TWORD t;
- 
+
 	if (rpole == NULL)
 		cerror("soumemb");
- 
+
 	/* check if tag name exists */
 	lsp = NULL;
 	for (sp = /* rpole->rb */ nscur->sup; sp != NULL; lsp = sp, sp = sp->snext)
@@ -1164,7 +1164,7 @@ talign(unsigned int ty, struct attr *apl)
 		if ((a = al->iarg(0)) == 0) {
 			uerror("no alignment");
 			a = ALINT;
-		} 
+		}
 		return a;
 	}
 
@@ -1439,7 +1439,7 @@ edelay(NODE *p)
 }
 
 /*
- * Traverse through the array args, evaluate them and put the 
+ * Traverse through the array args, evaluate them and put the
  * resulting temp numbers in the dim fields.
  */
 static void
@@ -2018,7 +2018,7 @@ arglist(NODE *n)
 		if (ty == UNIONTY &&
 		    attr_find(ap[j]->n_ap, GCC_ATYP_TRANSP_UNION)){
 			/* transparent unions must have compatible types
-			 * shortcut here: if pointers, set void *, 
+			 * shortcut here: if pointers, set void *,
 			 * otherwise btype.
 			 */
 			struct symtab *sp = strmemb(ap[j]->n_ap);
@@ -2173,7 +2173,7 @@ tymerge(NODE *typ, NODE *idp)
 	/* now idp is a single node: fix up type */
 	if ((t = ctype(idp->n_type)) != idp->n_type)
 		idp->n_type = t;
-	
+
 	if (idp->n_op != NAME) {
 		for (p = idp->n_left; p->n_op != NAME; p = p->n_left)
 			nfree(p);
@@ -3136,9 +3136,9 @@ cxop(int op, NODE *l, NODE *r)
 
 	case PLUS:
 	case MINUS:
-		p = comop(p, buildtree(ASSIGN, structref(ccopy(q), DOT, real), 
+		p = comop(p, buildtree(ASSIGN, structref(ccopy(q), DOT, real),
 		    buildtree(op, real_l, real_r)));
-		p = comop(p, buildtree(ASSIGN, structref(ccopy(q), DOT, imag), 
+		p = comop(p, buildtree(ASSIGN, structref(ccopy(q), DOT, imag),
 		    buildtree(op, imag_l, imag_r)));
 		break;
 
@@ -3310,15 +3310,15 @@ cxconj(NODE *p)
 NODE *
 cxret(NODE *p, NODE *q)
 {
-//printf("cxret\n");
-//fwalk(p, eprint, 0);
+/* printf("cxret\n"); */
+/* fwalk(p, eprint, 0); */
 	if (ANYCX(q)) { /* Return complex type */
 		p = mkcmplx(p, strmemb(q->n_ap)->stype);
 	} else if (ISFTY(q->n_type) || ISITY(q->n_type)) { /* real or imag */
 		p = structref(p, DOT, ISFTY(q->n_type) ? real : imag);
 		if (p->n_type != q->n_type)
 			p = cast(p, q->n_type, 0);
-	} else 
+	} else
 		cerror("cxred failing type");
 	return p;
 }

--- a/cc/cxxcom/trees.c
+++ b/cc/cxxcom/trees.c
@@ -56,7 +56,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 /*
@@ -651,7 +651,7 @@ nametree(struct symtab *sp)
 #ifndef NO_C_BUILTINS
 	if (sp->sname[0] == '_' && strncmp(sp->sname, "__builtin_", 10) == 0)
 		return p;  /* do not touch builtins here */
-	
+
 #endif
 
 	if (sp->sflags & STNODE) {
@@ -709,7 +709,7 @@ ccast(NODE *p, TWORD t, TWORD u, union dimfun *df, struct attr *ap)
 {
 	NODE *q;
 
-	/* let buildtree do typechecking (and casting) */ 
+	/* let buildtree do typechecking (and casting) */
 	q = block(NAME, NIL, NIL, t, df, ap);
 	p = buildtree(ASSIGN, q, p);
 	nfree(p->n_left);
@@ -741,8 +741,8 @@ concast(NODE *p, TWORD t)
 	if ((p->n_type & TMASK) || (t & TMASK)) /* no cast of pointers */
 		return 0;
 
-//printf("concast till %d\n", t);
-//fwalk(p, eprint, 0);
+/* printf("concast till %d\n", t); */
+/* fwalk(p, eprint, 0); */
 
 #define	TYPMSK(y) ((((1LL << (y-1))-1) << 1) | 1)
 	if (p->n_op == ICON) {
@@ -777,7 +777,7 @@ concast(NODE *p, TWORD t)
 		}
 	}
 	p->n_type = t;
-//fwalk(p, eprint, 0);
+/* fwalk(p, eprint, 0); */
 	return 1;
 }
 
@@ -1605,18 +1605,18 @@ icons(NODE *p)
 	return(val);
 }
 
-/* 
+/*
  * the intent of this table is to examine the
  * operators, and to check them for
  * correctness.
- * 
+ *
  * The table is searched for the op and the
  * modified type (where this is one of the
  * types INT (includes char and short), LONG,
  * DOUBLE (includes FLOAT), and POINTER
- * 
+ *
  * The default action is to make the node type integer
- * 
+ *
  * The actions taken include:
  * 	PUN	  check for puns
  * 	CVTL	  convert the left operand
@@ -1630,7 +1630,7 @@ icons(NODE *p)
  * 	NCVT	  do not convert the operands
  * 	OTHER	  handled by code
  * 	NCVTR	  convert the left operand, not the right...
- * 
+ *
  */
 
 # define MINT 01	/* integer */
@@ -1883,7 +1883,7 @@ doszof(NODE *p)
 		df++;
 		ty = DECREF(ty);
 	}
-	rv = buildtree(MUL, rv, 
+	rv = buildtree(MUL, rv,
 	    xbcon(tsize(ty, p->n_df, p->n_ap)/SZCHAR, NULL, INTPTR));
 	tfree(p);
 	arrstkp = 0; /* XXX - may this fail? */
@@ -1924,7 +1924,7 @@ eprint(NODE *p, int down, int *a, int *b)
 # endif
 
 /*
- * Emit everything that should be emitted on the left side 
+ * Emit everything that should be emitted on the left side
  * of a comma operator, and remove the operator.
  * Do not traverse through QUEST, ANDAND and OROR.
  * Enable this for all targets when stable enough.
@@ -2030,13 +2030,13 @@ andorbr(NODE *p, int _true, int _false)
 	int o, lab;
 
 	lab = -1;
-	switch (o = p->n_op) { 
+	switch (o = p->n_op) {
 	case EQ:
 	case NE:
 		/*
 		 * Remove redundant EQ/NE nodes.
 		 */
-		while (((o = p->n_left->n_op) == EQ || o == NE) && 
+		while (((o = p->n_left->n_op) == EQ || o == NE) &&
 		    p->n_right->n_op == ICON) {
 			o = p->n_op;
 			q = p->n_left;
@@ -2060,7 +2060,7 @@ andorbr(NODE *p, int _true, int _false)
 #endif
 			} else
 				break; /* XXX - should always be false */
-			
+
 		}
 		/* FALLTHROUGH */
 	case LE:
@@ -2339,7 +2339,7 @@ delasgop(NODE *p)
 			/* Now the left side of node p has no side effects. */
 			/* side effects on the right side must be obeyed */
 			p = delasgop(p);
-			
+
 			r = buildtree(ASSIGN, r, ll);
 			r = delasgop(r);
 			ecode(r);
@@ -2355,7 +2355,7 @@ delasgop(NODE *p)
 			p->n_right = delasgop(p->n_right);
 			p->n_right = clocal(p->n_right);
 		}
-		
+
 	} else {
 		if (coptype(p->n_op) == LTYPE)
 			return p;
@@ -2439,7 +2439,7 @@ rdualfld(NODE *p, TWORD t, TWORD ct, int off, int fsz)
 }
 
 /*
- * Write val to a (unaligned) bitfield with length fsz positioned off bits  
+ * Write val to a (unaligned) bitfield with length fsz positioned off bits
  * from d. Bitfield type is t, and type to use when writing is ct.
  * neither f nor d should have any side effects if copied.
  * Multiples of ct are supposed to be written without problems.
@@ -2447,33 +2447,33 @@ rdualfld(NODE *p, TWORD t, TWORD ct, int off, int fsz)
  */
 static NODE *
 wrualfld(NODE *val, NODE *d, TWORD t, TWORD ct, int off, int fsz)
-{ 
+{
 	NODE *p, *q, *r, *rn, *s;
 	int ctsz, t2f, inbits;
- 
+
 	ctsz = (int)tsize(ct, 0, 0);
-  
+
 	ct = ENUNSIGN(ct);
 	d = makety(d, PTR|ct, 0, 0, 0);
 
 	for (t2f = 0; off > ctsz; t2f++, off -= ctsz)
 		;
- 
+
 	if (off + fsz <= ctsz) {
 		r = tempnode(0, ct, 0, 0);
 
 		/* only one operation needed */
-		d = buildtree(UMUL, buildtree(PLUS, d, bcon(t2f)), 0);	
-		p = ccopy(d); 
+		d = buildtree(UMUL, buildtree(PLUS, d, bcon(t2f)), 0);
+		p = ccopy(d);
 		p = TYPAND(p, xbcon(~(SZMASK(fsz) << off), 0, ct), ct);
 
 		val = makety(val, ct, 0, 0, 0);
 		q = TYPAND(val, xbcon(SZMASK(fsz), 0, ct), ct);
 		q = buildtree(ASSIGN, ccopy(r), q);
 
-		q = TYPLS(q, bcon(off), ct);   
+		q = TYPLS(q, bcon(off), ct);
 		p = TYPOR(p, q, ct);
-		p = makety(p, t, 0, 0, 0);     
+		p = makety(p, t, 0, 0, 0);
 		rn = buildtree(ASSIGN, d, p);
 		rn = buildtree(COMOP, rn, makety(r, t, 0, 0, 0));
 	} else {
@@ -2483,8 +2483,8 @@ wrualfld(NODE *val, NODE *d, TWORD t, TWORD ct, int off, int fsz)
 		r = buildtree(UMUL, buildtree(PLUS, ccopy(d), bcon(t2f)), 0);
 		p = ccopy(r);
 		p = TYPAND(p, xbcon(SZMASK(off), 0, ct), ct);
-		q = ccopy(val); 
-		q = TYPLS(q, bcon(off), t);  
+		q = ccopy(val);
+		q = TYPLS(q, bcon(off), t);
 		q = makety(q, ct, 0, 0, 0);
 		p = TYPOR(p, q, ct);
 		rn = buildtree(ASSIGN, r, p);
@@ -2586,7 +2586,7 @@ rmfldops(NODE *p)
 			q = q->n_left;
 			t1 = tempnode(0, q->n_left->n_type, 0, 0);
 			r = buildtree(ASSIGN, ccopy(t1), q->n_left);
-			
+
 			bt = bt ? block(COMOP, bt, r, INT, 0, 0) : r;
 			q->n_left = t1;
 		}
@@ -2627,7 +2627,7 @@ rmfldops(NODE *p)
 			q = buildtree(COMOP, q, r);
 			r = wrualfld(t4, t1, t, ct, foff, fsz);
 			q = buildtree(COMOP, q, r);
-		
+
 			if (bt)
 				q = block(COMOP, bt, q, t, 0, 0);
 			nfree(p->n_left);
@@ -2671,7 +2671,7 @@ ecomp(NODE *p)
 
 
 #if defined(MULTIPASS)
-void	
+void
 p2tree(NODE *p)
 {
 	struct symtab *q;
@@ -2861,7 +2861,7 @@ delvoid(NODE *p, void *arg)
 		} else
 			p->n_type = (p->n_type & ~BTMASK) | BOOL_TYPE;
 	}
-		
+
 }
 
 /*
@@ -2915,7 +2915,7 @@ pprop(NODE *p, TWORD t, struct attr *ap)
 		t2 = p->n_left->n_type;
 		if (p->n_left->n_op == TEMP) {
 			/* Will be converted to memory in pass2 */
-			if (!ISPTR(t2) && DECREF(t) != t2) 
+			if (!ISPTR(t2) && DECREF(t) != t2)
 				; /* XXX cannot convert this */
 			else
 				p->n_left->n_type = DECREF(t);
@@ -2946,7 +2946,7 @@ pprop(NODE *p, TWORD t, struct attr *ap)
 			if (ISPTR(p->n_right->n_type))
 				break; /* change both */
 			p->n_left = pprop(p->n_left, t, ap);
-		} else 
+		} else
 			p->n_right = pprop(p->n_right, t, ap);
 		return p;
 
@@ -3015,11 +3015,11 @@ rmpconv(NODE *p)
 #endif
 
 void
-ecode(NODE *p)	
+ecode(NODE *p)
 {
 	/* walk the tree and write out the nodes.. */
 
-	if (nerrors)	
+	if (nerrors)
 		return;
 
 #ifdef GCC_COMPAT
@@ -3042,8 +3042,8 @@ ecode(NODE *p)
 	walkf(p, delvoid, 0);
 #ifdef PCC_DEBUG
 	if (xdebug) {
-		printf("Fulltree:\n"); 
-		fwalk(p, eprint, 0); 
+		printf("Fulltree:\n");
+		fwalk(p, eprint, 0);
 	}
 #endif
 	p2tree(p);
@@ -3244,12 +3244,12 @@ cdope(int op)
 	return 0; /* XXX gcc */
 }
 
-/* 
+/*
  * make a fresh copy of p
  */
 NODE *
-ccopy(NODE *p) 
-{  
+ccopy(NODE *p)
+{
 	NODE *q;
 
 	q = talloc();
@@ -3258,7 +3258,7 @@ ccopy(NODE *p)
 	switch (coptype(q->n_op)) {
 	case BITYPE:
 		q->n_right = ccopy(p->n_right);
-	case UTYPE: 
+	case UTYPE:
 		q->n_left = ccopy(p->n_left);
 	}
 

--- a/cc2/cc2.nova.c
+++ b/cc2/cc2.nova.c
@@ -37,7 +37,7 @@
  * Peephole optimizer for Nova.
  * It is mandatory for this program to be run on the assembler file
  * after compilation, to cleanup short-distance jumps/loads/stores.
- * 
+ *
  */
 #define BEGFTN	"#BEGFTN"
 #define ENDFTN	"#ENDFTN"
@@ -295,7 +295,7 @@ movecon(void)
 	} else
 		mb = DLIST_PREV(&mpole, link);
 	mblow = mb;
-//printf("movecon1: mblow %p curaddr %d\n", mblow, curaddr);
+/* printf("movecon1: mblow %p curaddr %d\n", mblow, curaddr); */
 	/*
 	 * First handle constants at the beginning of the function.
 	 * iterate backwards to get constants in the correct order.
@@ -326,7 +326,7 @@ movecon(void)
 	}
 	if (curaddr <= 128)
 		return; /* <= 128 entries */
-//printf("movecon2: mblow %p curaddr %d\n", mblow, curaddr);
+/* printf("movecon2: mblow %p curaddr %d\n", mblow, curaddr); */
 	/*
 	 * Second; move constants at the end of the function.
 	 */
@@ -339,7 +339,7 @@ movecon(void)
 				break;
 	}
 	mbhigh = mb;
-//printf("movecon3: mbhigh %p curaddr %d\n", mbhigh, curaddr);
+/* printf("movecon3: mbhigh %p curaddr %d\n", mbhigh, curaddr); */
 	for (; mb != &mpole; mb = DLIST_NEXT(mb, link)) {
 		if ((b = strchr(mb->name, '['))) {
 			s = strdup(b+1);
@@ -364,10 +364,10 @@ movecon(void)
 		DLIST_REMOVE(mb, link);
 		DLIST_INSERT_BEFORE(&mpole, mb, link);
 	}
-//printf("movecon5: mb %p curaddr %d\n", mb, curaddr);
+/* printf("movecon5: mb %p curaddr %d\n", mb, curaddr); */
 	if (curaddr <= 255)
 		return;
-//printf("movecon6: mb %p curaddr %d\n", mb, curaddr);
+/* printf("movecon6: mb %p curaddr %d\n", mb, curaddr); */
 	/*
 	 * Here begins the tricky part.
 	 * - Start at mblow. At the first memref insn start counting.
@@ -381,12 +381,12 @@ movecon(void)
 	curcnt = 0;
 	mbpout = NULL;
 
-//printf("movecon7: mb %p curaddr %d\n", mb, curaddr);
+/* printf("movecon7: mb %p curaddr %d\n", mb, curaddr); */
 	for (mb = DLIST_NEXT(mblow, link); mb != mbhigh;
 	    mb = DLIST_NEXT(mb, link)) {
 		int ityp = itype(mb->name);
 
-//printf("movecon4: mb %p mbnum %d lnum %d line %s\n", mb, mb->off, curcnt, mb->name);
+/* printf("movecon4: mb %p mbnum %d lnum %d line %s\n", mb, mb->off, curcnt, mb->name); */
 		if (curcnt)
 			curcnt++;
 		if (ityp == IMREF && (b = strchr(mb->name, '['))) {
@@ -434,7 +434,7 @@ movecon(void)
 		} else
 			errx(1, "FIXME long distance");
 	}
-//printf("movecon8: mb %p mbnum %d\n", mb, mb->off);
+/* printf("movecon8: mb %p mbnum %d\n", mb, mb->off); */
 }
 
 /*

--- a/common/softfloat.c
+++ b/common/softfloat.c
@@ -154,19 +154,20 @@ ffloat_unmake(SFP sfp, int *sign, int *exp, MINT *m)
 	return (sfp->fp[0] == 0xffff7fff ? SOFT_INFINITE : SOFT_NORMAL);
 }
 
-FPI fpi_ffloat = { 
-	.nbits = FFLOAT_MANT_DIG,  
-	.storage = 32,
-        .bias = 128,
-	.minexp = FFLOAT_MIN_EXP-1,
-	.maxexp = FFLOAT_MAX_EXP-1,
-	.min10exp = FFLOAT_MIN_10_EXP-1,
-	.max10exp = FFLOAT_MAX_10_EXP-1,
-	.dig = FFLOAT_DIG,
-	.expadj = 0,
+FPI fpi_ffloat = {
+	FFLOAT_MANT_DIG,        /* nbits */
+	32,                     /* storage */
+	128,                    /* bias */
+	FFLOAT_MIN_EXP-1,       /* minexp */
+	FFLOAT_MAX_EXP-1,       /* maxexp */
+	FFLOAT_MIN_10_EXP-1,    /* min10exp */
+	FFLOAT_MAX_10_EXP-1,    /* max10exp */
+	FFLOAT_DIG,             /* dig */
+	0,                      /* expadj */
 
-	.make = ffloat_make,
-	.unmake = ffloat_unmake,
+	ffloat_make,            /* make */
+	ffloat_unmake,          /* unmake */
+	0                       /* classify */
 };
 
 static int
@@ -215,7 +216,7 @@ dfloat_make(SFP sfp, int typ, int sign, int exp, MINT *m)
 		break; /* no subnormal */
 	}
 	SD(("dfloat_make3: fp %08x %08x\n", sfp->fp[0], sfp->fp[1]));
-	
+
 }
 
 static int
@@ -236,20 +237,20 @@ dfloat_unmake(SFP sfp, int *sign, int *exp, MINT *m)
 	return t;
 }
 
-FPI fpi_dfloat = { 
-	.nbits = DFLOAT_MANT_DIG,  
-	.storage = 64,
-        .bias = 128,
-	.minexp = DFLOAT_MIN_EXP-1,
-	.maxexp = DFLOAT_MAX_EXP-1,
-	.min10exp = DFLOAT_MIN_10_EXP-1,
-	.max10exp = DFLOAT_MAX_10_EXP-1,
-	.dig = DFLOAT_DIG,
-	.expadj = 0,
+FPI fpi_dfloat = {
+	DFLOAT_MANT_DIG,        /* nbits */
+	64,                     /* storage */
+	128,                    /* bias */
+	DFLOAT_MIN_EXP-1,       /* minexp */
+	DFLOAT_MAX_EXP-1,       /* maxexp */
+	DFLOAT_MIN_10_EXP-1,    /* min10exp */
+	DFLOAT_MAX_10_EXP-1,    /* max10exp */
+	DFLOAT_DIG,             /* dig */
+	0,                      /* expadj */
 
-	.make = dfloat_make,
-	.unmake = dfloat_unmake,
-	.classify = dfloat_classify,
+	dfloat_make,            /* make */
+	dfloat_unmake,          /* unmake */
+	dfloat_classify         /* classify */
 };
 #endif
 
@@ -317,7 +318,7 @@ ieee32_make(SFP sfp, int typ, int sign, int exp, MINT *m)
 		break;
 	}
 	SD(("ieee32_make3: fp %08x\n", sfp->fp[0]));
-	
+
 }
 
 static int
@@ -340,20 +341,20 @@ ieee32_unmake(SFP sfp, int *sign, int *exp, MINT *m)
 	return v;
 }
 
-FPI fpi_binary32 = { 
-	.nbits = IEEEFP_32_MANT_DIG,  
-	.storage = 32,
-        .bias = 127,
-	.minexp = IEEEFP_32_MIN_EXP-1,
-	.maxexp = IEEEFP_32_MAX_EXP-1,
-	.min10exp = IEEEFP_32_MIN_10_EXP-1,
-	.max10exp = IEEEFP_32_MAX_10_EXP-1,
-	.dig = IEEEFP_32_DIG,
-	.expadj = 1,
+FPI fpi_binary32 = {
+	IEEEFP_32_MANT_DIG,     /* nbits */
+	32,                     /* storage */
+	127,                    /* bias */
+	IEEEFP_32_MIN_EXP-1,    /* minexp */
+	IEEEFP_32_MAX_EXP-1,    /* maxexp */
+	IEEEFP_32_MIN_10_EXP-1, /* min10exp */
+	IEEEFP_32_MAX_10_EXP-1, /* max10exp */
+	IEEEFP_32_DIG,          /* dig */
+	1,                      /* expadj */
 
-	.make = ieee32_make,
-	.unmake = ieee32_unmake,
-	.classify = ieee32_classify,
+	ieee32_make,            /* make */
+	ieee32_unmake,          /* unmake */
+	ieee32_classify         /* classify */
 };
 #endif
 
@@ -440,20 +441,20 @@ ieee64_make(SFP sfp, int typ, int sign, int exp, MINT *m)
 }
 
 FPI fpi_binary64 = {
-	.nbits = IEEEFP_64_MANT_DIG,
-	.storage = 64,
-	.bias = 1023,
-	.minexp = IEEEFP_64_MIN_EXP-1,
-	.maxexp = IEEEFP_64_MAX_EXP-1,
-	.min10exp = IEEEFP_64_MIN_10_EXP-1,
-	.max10exp = IEEEFP_64_MAX_10_EXP-1,
-	.dig = IEEEFP_64_DIG,
-	.expadj = 1,
+	IEEEFP_64_MANT_DIG,     /* nbits */
+	64,                     /* storage */
+	1023,                   /* bias */
+	IEEEFP_64_MIN_EXP-1,    /* minexp */
+	IEEEFP_64_MAX_EXP-1,    /* maxexp */
+	IEEEFP_64_MIN_10_EXP-1, /* min10exp */
+	IEEEFP_64_MAX_10_EXP-1, /* max10exp */
+	IEEEFP_64_DIG,          /* dig */
+	1,                      /* expadj */
 
-	.make = ieee64_make,
-	.unmake = ieee64_unmake,
-	.classify = ieee64_classify,
-};      
+	ieee64_make,            /* make */
+	ieee64_unmake,          /* unmake */
+	ieee64_classify         /* classify */
+};
 #endif
 
 #ifdef USE_IEEEFP_X80
@@ -528,7 +529,7 @@ ieeex80_unmake(SFP sfp, int *sign, int *exp, MINT *m)
 {
 	int t, v = ieeex80_classify(sfp);
 
-	SD(("ieeex80_unmake: %s %04x %08x %08x\n", 
+	SD(("ieeex80_unmake: %s %04x %08x %08x\n",
 	    sftyp[v], sfp->fp[2], sfp->fp[1], sfp->fp[0]));
 	*sign = (sfp->fp[2] >> 15) & 1;
 	*exp = (sfp->fp[2] & 0x7fff) - fpi_binaryx80.bias;
@@ -550,20 +551,20 @@ ieeex80_unmake(SFP sfp, int *sign, int *exp, MINT *m)
 
 /* IEEE double extended in its usual form, for example Intel 387 */
 FPI fpi_binaryx80 = {
-	.nbits = IEEEFP_X80_MANT_DIG,
-	.storage = 80,
-	.bias = 16383,
-	.minexp = IEEEFP_X80_MIN_EXP-1,
-	.maxexp = IEEEFP_X80_MAX_EXP-1,
-	.min10exp = IEEEFP_X80_MIN_10_EXP-1,
-	.max10exp = IEEEFP_X80_MAX_10_EXP-1,
-	.dig = IEEEFP_X80_DIG,
-	.expadj = 1,
+	IEEEFP_X80_MANT_DIG,    /* nbits */
+	80,                     /* storage */
+	16383,                  /* bias */
+	IEEEFP_X80_MIN_EXP-1,   /* minexp */
+	IEEEFP_X80_MAX_EXP-1,   /* maxexp */
+	IEEEFP_X80_MIN_10_EXP-1,/* min10exp */
+	IEEEFP_X80_MAX_10_EXP-1,/* max10exp */
+	IEEEFP_X80_DIG,         /* dig */
+	1,                      /* expadj */
 
-	.make = ieeex80_make,
-	.unmake = ieeex80_unmake,
-	.classify = ieeex80_classify,
-};      
+	ieeex80_make,           /* make */
+	ieeex80_unmake,         /* unmake */
+	ieeex80_classify        /* classify */
+};
 #endif
 
 #ifdef USE_IEEEFP_X80
@@ -679,7 +680,7 @@ grsround(MINT *m, FPI *f)
 }
 
 /*
- * Return highest set bit in a.  
+ * Return highest set bit in a.
  * Bit numbering starts with 0.
  */
 static int
@@ -901,7 +902,7 @@ soft_plus(SFP x1p, SFP x2p, TWORD t)
 
 	c1 = LDBLPTR->unmake(x1p, &s1, &e1, &m1);
 	c2 = LDBLPTR->unmake(x2p, &s2, &e2, &m2);
-	SD(("soft_plus: c1 %s c2 %s s1 %d s2 %d e1 %d e2 %d\n", 
+	SD(("soft_plus: c1 %s c2 %s s1 %d s2 %d e1 %d e2 %d\n",
 	    sftyp[c1], sftyp[c2], s1, s2, e1, e2));
 
 	ediff = e1 - e2;
@@ -1031,7 +1032,7 @@ soft_div(SFP x1p, SFP x2p, TWORD t)
 	c1 = LDBLPTR->unmake(x1p, &s1, &e1, &m1);
 	c2 = LDBLPTR->unmake(x2p, &s2, &e2, &m2);
 
-	SD(("soft_div: c1 %s c2 %s s1 %d s2 %d e1 %d e2 %d\n", 
+	SD(("soft_div: c1 %s c2 %s s1 %d s2 %d e1 %d e2 %d\n",
 	    sftyp[c1], sftyp[c2], s1, s2, e1, e2));
 	if (c1 == SOFT_NAN || c2 == SOFT_NAN) {
 		c1 = SOFT_NAN, s1 = 1;
@@ -1107,8 +1108,8 @@ soft_isz(SFP sfp)
 	return r;
 }
 
-#define	SFLEFTLESS	1	
-#define	SFLEFTEQ	2	
+#define	SFLEFTLESS	1
+#define	SFLEFTEQ	2
 #define	SFLEFTGTR	3
 
 /*
@@ -1266,7 +1267,7 @@ decbig(char *str, MINT *mmant, MINT *mexp)
 			if (gotdot)
 				exp10--;
 			continue;
-	
+
 		case '.':
 			gotdot = 1;
 			continue;
@@ -1339,7 +1340,7 @@ hexbig(char *str, MINT *mmant, MINT *mexp)
 			if (gotdot)
 				e3 -= 4;
 			continue;
-	
+
 		case '.':
 			gotdot = 1;
 			continue;
@@ -1374,7 +1375,7 @@ str2num(char *str, int *exp, MINT *m, struct FPI *fpi)
 {
 	MINT d, mm, me;
 	int t, u, rv;
-	
+
 	*exp = 0;
 
 	MINTDECL(d);
@@ -1475,12 +1476,12 @@ strtosf(SFP sfp, char *str, TWORD tw)
 
 
 	LDBLPTR->make(sfp, rv, 0, e, &m);
-//	soft_fp2fp(sfp, tw);
+	/* soft_fp2fp(sfp, tw); */
 
 #ifdef DEBUGFP
 	{
 		long double ld = strtold(str, NULL);
-//		ld = tw == DOUBLE ? (double)ld : tw == FLOAT ? (float)ld : ld;
+		/* ld = tw == DOUBLE ? (double)ld : tw == FLOAT ? (float)ld : ld; */
 		if (ld != sfp2ld(sfp))
 			fpwarn("strtosf", sfp2ld(sfp), ld);
 	}

--- a/f77/f77/f77.c
+++ b/f77/f77/f77.c
@@ -59,7 +59,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -988,14 +988,14 @@ strlist_exec(struct strlist *l)
 	si.cb = sizeof(STARTUPINFO);
 	ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
 
-	ok = CreateProcess(NULL,  // the executable program
-		cmd,   // the command line arguments
-		NULL,       // ignored
-		NULL,       // ignored
-		TRUE,       // inherit handles
+	ok = CreateProcess(NULL,  /* the executable program */
+		cmd,   /* the command line arguments */
+		NULL,       /* ignored */
+		NULL,       /* ignored */
+		TRUE,       /* inherit handles */
 		HIGH_PRIORITY_CLASS,
-		NULL,       // ignored
-		NULL,       // ignored
+		NULL,       /* ignored */
+		NULL,       /* ignored */
 		&si,
 		&pi);
 

--- a/mip/optim2.c
+++ b/mip/optim2.c
@@ -64,7 +64,7 @@ static struct varinfo defsites;
 
 void bblocks_build(struct p2env *);
 void cfg_build(struct p2env *);
-void cfg_dfs(struct basicblock *bb, unsigned int parent, 
+void cfg_dfs(struct basicblock *bb, unsigned int parent,
 	     struct bblockinfo *bbinfo);
 void dominators(struct p2env *);
 struct basicblock *
@@ -91,7 +91,7 @@ void TraceSchedule(struct p2env*) ;
 static void do_cse(struct p2env* p2e) ;
 #endif
 
-/* Walk the complete set, performing a function on each node. 
+/* Walk the complete set, performing a function on each node.
  * if type is given, apply function on only that type */
 void WalkAll(struct p2env* p2e, void (*f) (NODE*, void*), void* arg, int type) ;
 
@@ -133,7 +133,7 @@ optimize(struct p2env *p2e)
 		bblocks_build(p2e);
 		BDEBUG(("Calling cfg_build\n"));
 		cfg_build(p2e);
-	
+
 #ifdef PCC_DEBUG
 		printflowdiagram(p2e, "first");
 #endif
@@ -172,14 +172,14 @@ optimize(struct p2env *p2e)
 
 		BDEBUG(("Calling remunreach\n"));
 /*		remunreach(p2e); */
-		
+
 		/*
 		 * Recalculate basic blocks and cfg that was destroyed
 		 * by removephi
 		 */
 		/* first, clean up all what deljumps should have done, and more */
 
-		/* TODO: add the basic blocks done by the ssa code by hand. 
+		/* TODO: add the basic blocks done by the ssa code by hand.
 		 * The trace scheduler should not change the order in
 		 * which blocks are executed or what data is calculated.
 		 * Thus, the BBlock order should remain correct.
@@ -265,7 +265,7 @@ dumplink(struct dlnod *dl)
 			printf("EROU(%p)\n", dl);
 		} else {
 			static char *str[] = { 0, "LABEL", "JBR", "CBR" };
-			printf("%s(%p) %d refc %d ref %p\n", str[dl->op], 
+			printf("%s(%p) %d refc %d ref %p\n", str[dl->op],
 			    dl, dl->labno, dl->refc, dl->ref);
 		}
 	}
@@ -311,7 +311,7 @@ listsetup(struct interpass *ipole, struct dlnod *dl)
 				if (q->n_left->n_op == ICON) {
 					p->op = JBR;
 					p->labno = (int)getlval(q->n_left);
-				} else 
+				} else
 					p->op = STMT;
 				break;
 			case CBRANCH:
@@ -320,7 +320,7 @@ listsetup(struct interpass *ipole, struct dlnod *dl)
 				break;
 			case ASSIGN:
 				/* remove ASSIGN to self for regs */
-				if (q->n_left->n_op == REG && 
+				if (q->n_left->n_op == REG &&
 				    q->n_right->n_op == REG &&
 				    regno(q->n_left) == regno(q->n_right)) {
 					nip = DLIST_PREV(ip, qelem);
@@ -532,7 +532,7 @@ ivloop:
 		if ((p3 = p3->forw) == 0 || p3==p1 || --n==0)
 			return(p1);
 	} while (p3->op!=CBR || p3->labno!=p1->forw->labno);
-	do 
+	do
 		if ((p1 = p1->back) == 0)
 			return(p);
 	while (p1!=p3);
@@ -726,7 +726,7 @@ bblocks_build(struct p2env *p2e)
 	low = p2e->ipp->ip_lblnum;
 	high = p2e->epp->ip_lblnum;
 
-	/* 
+	/*
 	 * First statement is a leader.
 	 * Any statement that is target of a jump is a leader.
 	 * Any statement that immediately follows a jump is a leader.
@@ -756,7 +756,7 @@ bblocks_build(struct p2env *p2e)
 			count++;
 		}
 		bb->last = ip;
-		if ((ip->type == IP_NODE) && (ip->ip_node->n_op == GOTO || 
+		if ((ip->type == IP_NODE) && (ip->ip_node->n_op == GOTO ||
 		    ip->ip_node->n_op == CBRANCH))
 			bb = NULL;
 		if (ip->type == IP_PROLOG)
@@ -779,7 +779,7 @@ bblocks_build(struct p2env *p2e)
 	for (i = 0; i < p2e->labinfo.size; i++) {
 		p2e->labinfo.arr[i] = NULL;
 	}
-	
+
 	p2e->bbinfo.size = count + 1;
 	p2e->bbinfo.arr = tmpalloc(p2e->bbinfo.size * sizeof(struct basicblock *));
 	for (i = 0; i < p2e->bbinfo.size; i++) {
@@ -818,7 +818,7 @@ void
 cfg_build(struct p2env *p2e)
 {
 	/* Child and parent nodes */
-	struct cfgnode *cnode; 
+	struct cfgnode *cnode;
 	struct cfgnode *pnode;
 	struct basicblock *bb;
 	NODE *p;
@@ -856,7 +856,7 @@ cfg_build(struct p2env *p2e)
 	DLIST_FOREACH(bb, &p2e->bblocks, bbelem) {
 		if (bb->first->type == IP_EPILOG)
 			break;
-	
+
 		cnode = tmpalloc(sizeof(struct cfgnode));
 		pnode = tmpalloc(sizeof(struct cfgnode));
 		pnode->bblock = bb;
@@ -865,7 +865,7 @@ cfg_build(struct p2env *p2e)
 		if (bb->last->type == IP_NODE && p->n_op == GOTO) {
 			if (p->n_left->n_op == ICON) {
 				if (getlval(p->n_left) - p2e->labinfo.low > p2e->labinfo.size)
-					comperr("Label out of range: %d, base %d", 
+					comperr("Label out of range: %d, base %d",
 					    getlval(p->n_left), p2e->labinfo.low);
 				cnode->bblock = p2e->labinfo.arr[getlval(p->n_left) - p2e->labinfo.low];
 				SLIST_INSERT_LAST(&cnode->bblock->parents, pnode, cfgelem);
@@ -885,7 +885,7 @@ cfg_build(struct p2env *p2e)
 			continue;
 		}
 		if ((bb->last->type == IP_NODE) && p->n_op == CBRANCH) {
-			if (getlval(p->n_right) - p2e->labinfo.low > p2e->labinfo.size) 
+			if (getlval(p->n_right) - p2e->labinfo.low > p2e->labinfo.size)
 				comperr("Label out of range: %d", getlval(p->n_left));
 
 			cnode->bblock = p2e->labinfo.arr[getlval(p->n_right) - p2e->labinfo.low];
@@ -974,9 +974,9 @@ dominators(struct p2env *p2e)
 			if (cnode->bblock->dfnum ==0)
 				continue; /* Ignore unreachable code */
 
-			if (cnode->bblock->dfnum <= bb->dfnum) 
+			if (cnode->bblock->dfnum <= bb->dfnum)
 				sprime = cnode->bblock;
-			else 
+			else
 				sprime = p2e->bbinfo.arr[ancestorwithlowestsemi
 					      (cnode->bblock, &p2e->bbinfo)->semi];
 			if (sprime->dfnum < s->dfnum)
@@ -989,7 +989,7 @@ dominators(struct p2env *p2e)
 			if(TESTBIT(p->bucket, i)) {
 				v = p2e->bbinfo.arr[i];
 				y = ancestorwithlowestsemi(v, &p2e->bbinfo);
-				if (y->semi == v->semi) 
+				if (y->semi == v->semi)
 					v->idom = p->dfnum;
 				else
 					v->samedom = y->dfnum;
@@ -1029,8 +1029,8 @@ ancestorwithlowestsemi(struct basicblock *bblock, struct bblockinfo *bbinfo)
 	struct basicblock *v = bblock;
 
 	while (v->ancestor != 0) {
-		if (bbinfo->arr[v->semi]->dfnum < 
-		    bbinfo->arr[u->semi]->dfnum) 
+		if (bbinfo->arr[v->semi]->dfnum <
+		    bbinfo->arr[u->semi]->dfnum)
 			u = v;
 		v = bbinfo->arr[v->ancestor];
 	}
@@ -1042,7 +1042,7 @@ computeDF(struct p2env *p2e, struct basicblock *bblock)
 {
 	struct cfgnode *cn;
 	int h, i;
-	
+
 	SLIST_FOREACH(cn, &bblock->child, chld) {
 		if (cn->bblock->idom != bblock->dfnum)
 			BITSET(bblock->df, cn->bblock->dfnum);
@@ -1052,9 +1052,9 @@ computeDF(struct p2env *p2e, struct basicblock *bblock)
 			continue;
 		computeDF(p2e, p2e->bbinfo.arr[h]);
 		for (i = 1; i < p2e->bbinfo.size; i++) {
-			if (TESTBIT(p2e->bbinfo.arr[h]->df, i) && 
+			if (TESTBIT(p2e->bbinfo.arr[h]->df, i) &&
 			    (p2e->bbinfo.arr[i] == bblock ||
-			     (bblock->dfnum != p2e->bbinfo.arr[i]->idom))) 
+			     (bblock->dfnum != p2e->bbinfo.arr[i]->idom)))
 			    BITSET(bblock->df, i);
 		}
 	}
@@ -1066,19 +1066,19 @@ void printDF(struct p2env *p2e)
 	int i;
 
 	printf("Dominance frontiers:\n");
-    
+
 	DLIST_FOREACH(bb, &p2e->bblocks, bbelem) {
 		printf("bb %d : ", bb->dfnum);
-	
+
 		for (i=1; i < p2e->bbinfo.size;i++) {
 			if (TESTBIT(bb->df,i)) {
 				printf("%d ",i);
 			}
 		}
-	    
+
 		printf("\n");
 	}
-    
+
 }
 
 
@@ -1092,7 +1092,7 @@ searchasg(NODE *p, void *arg)
 	struct pvarinfo *pv;
 	int tempnr;
 	struct varstack *stacke;
-    
+
 	if (p->n_op != ASSIGN)
 		return;
 
@@ -1100,17 +1100,17 @@ searchasg(NODE *p, void *arg)
 		return;
 
 	tempnr=regno(p->n_left)-defsites.low;
-    
+
 	BITSET(currbb->Aorig, tempnr);
-	
+
 	pv = tmpcalloc(sizeof(struct pvarinfo));
 	pv->next = defsites.arr[tempnr];
 	pv->bb = currbb;
 	pv->n_type = p->n_left->n_type;
-	
+
 	defsites.arr[tempnr] = pv;
-	
-	
+
+
 	if (SLIST_FIRST(&defsites.stack[tempnr])==NULL) {
 		stacke=tmpcalloc(sizeof (struct varstack));
 		stacke->tmpregno=0;
@@ -1152,17 +1152,17 @@ placePhiFunctions(struct p2env *p2e)
 	defsites.size = maxtmp - defsites.low + 1;
 	defsites.arr = tmpcalloc(defsites.size*sizeof(struct pvarinfo *));
 	defsites.stack = tmpcalloc(defsites.size*sizeof(SLIST_HEAD(, varstack)));
-	
+
 	for (i=0;i<defsites.size;i++)
-		SLIST_INIT(&defsites.stack[i]);	
-	
+		SLIST_INIT(&defsites.stack[i]);
+
 	/* Find all defsites */
 	DLIST_FOREACH(bb, &p2e->bblocks, bbelem) {
 		currbb = bb;
 		ip = bb->first;
 		bb->Aorig = setalloc(defsites.size);
 		bb->Aphi = setalloc(defsites.size);
-		
+
 		while (ip != bb->last) {
 			findTemps(ip);
 			ip = DLIST_NEXT(ip, qelem);
@@ -1182,7 +1182,7 @@ placePhiFunctions(struct p2env *p2e)
 			for (j = 0; j < p2e->bbinfo.size; j++) {
 				if (!TESTBIT(n->bb->df, j))
 					continue;
-				
+
 				if (TESTBIT(p2e->bbinfo.arr[j]->Aphi, i))
 					continue;
 
@@ -1190,18 +1190,18 @@ placePhiFunctions(struct p2env *p2e)
 				ntype = n->n_type;
 				k = 0;
 				/* Amount of predecessors for y */
-				SLIST_FOREACH(cnode, &y->parents, cfgelem) 
+				SLIST_FOREACH(cnode, &y->parents, cfgelem)
 					k++;
-				/* Construct phi(...) 
+				/* Construct phi(...)
 				*/
-			    
+
 				phifound=0;
-			    
+
 				SLIST_FOREACH(phi, &y->phi, phielem) {
 				    if (phi->tmpregno==i+defsites.low)
 					phifound++;
 				}
-			    
+
 				if (phifound==0) {
 					if (b2debug)
 					    printf("Phi in %d(%d) (%p) for %d\n",
@@ -1219,12 +1219,12 @@ placePhiFunctions(struct p2env *p2e)
 					}
 
 					phi = tmpcalloc(sizeof(struct phiinfo));
-			    
+
 					phi->tmpregno=i+defsites.low;
 					phi->size=k;
 					phi->n_type=ntype;
 					phi->intmpregno=tmpcalloc(k*sizeof(int));
-			    
+
 					SLIST_INSERT_LAST(&y->phi,phi,phielem);
 				} else {
 				    if (b2debug)
@@ -1247,33 +1247,33 @@ placePhiFunctions(struct p2env *p2e)
 /* Helper function for renamevar. */
 static void
 renamevarhelper(struct p2env *p2e,NODE *t,void *poplistarg)
-{	
+{
 	SLIST_HEAD(, varstack) *poplist=poplistarg;
 	int opty;
 	int tempnr;
 	int newtempnr;
 	int x;
 	struct varstack *stacke;
-	
+
 	if (t->n_op == ASSIGN && t->n_left->n_op == TEMP) {
 		renamevarhelper(p2e,t->n_right,poplist);
-				
+
 		tempnr=regno(t->n_left)-defsites.low;
-		
+
 		newtempnr=p2e->epp->ip_tmpnum++;
 		regno(t->n_left)=newtempnr;
-		
+
 		stacke=tmpcalloc(sizeof (struct varstack));
 		stacke->tmpregno=newtempnr;
 		SLIST_INSERT_FIRST(&defsites.stack[tempnr],stacke,varstackelem);
-		
+
 		stacke=tmpcalloc(sizeof (struct varstack));
 		stacke->tmpregno=tempnr;
 		SLIST_INSERT_FIRST(poplist,stacke,varstackelem);
 	} else {
 		if (t->n_op == TEMP) {
 			tempnr=regno(t)-defsites.low;
-		
+
 			if (SLIST_FIRST(&defsites.stack[tempnr])!=NULL) {
 				x=SLIST_FIRST(&defsites.stack[tempnr])->tmpregno;
 				if (x == 0) {
@@ -1283,9 +1283,9 @@ renamevarhelper(struct p2env *p2e,NODE *t,void *poplistarg)
 				regno(t)=x;
 			}
 		}
-		
+
 		opty = optype(t->n_op);
-		
+
 		if (opty != LTYPE)
 			renamevarhelper(p2e, t->n_left,poplist);
 		if (opty == BITYPE)
@@ -1309,23 +1309,23 @@ renamevar(struct p2env *p2e,struct basicblock *bb)
 
 	SLIST_FOREACH(phi,&bb->phi,phielem) {
 		tmpregno=phi->tmpregno-defsites.low;
-		
+
 		newtmpregno=p2e->epp->ip_tmpnum++;
 		phi->newtmpregno=newtmpregno;
 
 		stacke=tmpcalloc(sizeof (struct varstack));
 		stacke->tmpregno=newtmpregno;
 		SLIST_INSERT_FIRST(&defsites.stack[tmpregno],stacke,varstackelem);
-		
+
 		stacke=tmpcalloc(sizeof (struct varstack));
 		stacke->tmpregno=tmpregno;
-		SLIST_INSERT_FIRST(&poplist,stacke,varstackelem);		
+		SLIST_INSERT_FIRST(&poplist,stacke,varstackelem);
 	}
 
 
 	ip=bb->first;
 
-	while (1) {		
+	while (1) {
 		if ( ip->type == IP_NODE) {
 			renamevarhelper(p2e,ip->ip_node,&poplist);
 		}
@@ -1339,10 +1339,10 @@ renamevar(struct p2env *p2e,struct basicblock *bb)
 	SLIST_FOREACH(cn, &bb->child, chld) {
 		j=0;
 
-		SLIST_FOREACH(cfgn2, &cn->bblock->parents, cfgelem) { 
+		SLIST_FOREACH(cfgn2, &cn->bblock->parents, cfgelem) {
 			if (cfgn2->bblock->dfnum==bb->dfnum)
 				break;
-			
+
 			j++;
 		}
 
@@ -1360,7 +1360,7 @@ renamevar(struct p2env *p2e,struct basicblock *bb)
 
 	SLIST_FOREACH(stacke,&poplist,varstackelem) {
 		tmpregno=stacke->tmpregno;
-		
+
 		defsites.stack[tmpregno].q_forw=defsites.stack[tmpregno].q_forw->varstackelem.q_forw;
 	}
 }
@@ -1377,10 +1377,10 @@ getconst(NODE *p)
 {
 	int ix;
 
-	if (p->n_op == ASSIGN && p->n_left->n_op == TEMP && 
+	if (p->n_op == ASSIGN && p->n_left->n_op == TEMP &&
 	    p->n_right->n_op == ICON) {
 		ix = regno(p->n_left) - cpi.ipb;
-//printf("Found %d val " CONFMT " name \n", regno(p->n_left), getlval(p->n_right));
+/* printf("Found %d val " CONFMT " name \n", regno(p->n_left), getlval(p->n_right)); */
 		if (cpi.valp[ix])
 			comperr("TEMP %d found", regno(p->n_left));
 		cpi.valp[ix] = 1;
@@ -1397,13 +1397,13 @@ static int replaced;
 
 static void
 replconst(NODE *p)
-{  
+{
 
 	if (p->n_op == ASSIGN && p->n_left->n_op == TEMP) {
 		replconst(p->n_right);
 	} else if (p->n_op == TEMP) {
 		if (cpi.valp[regno(p) - cpi.ipb]) {
-//printf("replacing %d %p\n", regno(p), p);
+/* printf("replacing %d %p\n", regno(p), p); */
 			p->n_op = ICON;
 			setlval(p, cpi.conp[regno(p) - cpi.ipb]);
 			p->n_name = cpi.namep[regno(p) - cpi.ipb];
@@ -1472,16 +1472,16 @@ removephi(struct p2env *p2e)
 	int label=0;
 	int newlabel;
 
-	DLIST_FOREACH(bb, &p2e->bblocks, bbelem) {		
+	DLIST_FOREACH(bb, &p2e->bblocks, bbelem) {
 		SLIST_FOREACH(phi,&bb->phi,phielem) {
 			/* Look at only one, notice break at end */
 			i=0;
-			
-			SLIST_FOREACH(cfgn, &bb->parents, cfgelem) { 
+
+			SLIST_FOREACH(cfgn, &bb->parents, cfgelem) {
 
 				bbparent = cfgn->bblock;	/* cfg parent basic block */
 				pip = bbparent->last;		/* last stmt in parent bb (goto, ...) */
-				
+
 				complex = pred_unknown ;
 				BDEBUG(("removephi: %p in %d",pip,bb->dfnum));
 
@@ -1505,7 +1505,7 @@ removephi(struct p2env *p2e)
 					    /* PANIC */
 					comperr("Assumption blown in rem-phi") ;
 				}
-       
+
 				BDEBUG((" Complex: %d ",complex)) ;
 
 				switch (complex) {
@@ -1519,7 +1519,7 @@ removephi(struct p2env *p2e)
 							     mktemp(phi->intmpregno[i],n_type),
 							     n_type));
 							BDEBUG(("(%p, %d -> %d) ", ip, phi->intmpregno[i], phi->newtmpregno));
-				
+
 							DLIST_INSERT_BEFORE((bbparent->last), ip, qelem);
 						}
 					}
@@ -1527,7 +1527,7 @@ removephi(struct p2env *p2e)
 				  case pred_cond:
 					/* Here, we need a jump pad */
 					newlabel=getlab2();
-			
+
 					ip = tmpalloc(sizeof(struct interpass));
 					ip->type = IP_DEFLAB;
 					/* Line number?? ip->lineno; */
@@ -1555,14 +1555,14 @@ removephi(struct p2env *p2e)
 					pip->ip_node->n_left->n_label=newlabel;
 					break ;
 				  case pred_falltrough:
-					if (bb->first->type == IP_DEFLAB) { 
-						label = bb->first->ip_lbl; 
+					if (bb->first->type == IP_DEFLAB) {
+						label = bb->first->ip_lbl;
 						BDEBUG(("falltrough label %d\n", label));
 					} else {
 						comperr("BBlock has no label?") ;
 					}
 
-					/* 
+					/*
 					 * add a jump to us. We _will_ be, or already have, added code in between.
 					 * The code is created in the wrong order and switched at the insert, thus
 					 * comming out correctly
@@ -1596,10 +1596,10 @@ removephi(struct p2env *p2e)
 	}
 }
 
-    
+
 /*
  * Remove unreachable nodes in the CFG.
- */ 
+ */
 
 void
 remunreach(struct p2env *p2e)
@@ -1619,7 +1619,7 @@ remunreach(struct p2env *p2e)
 
 		/* Need the epilogue node for other parts of the
 		   compiler, set its label to 0 and backend will
-		   handle it. */ 
+		   handle it. */
 		if (bb->first->type == IP_EPILOG) {
 			bb->first->ip_lbl = 0;
 			bb = nbb;
@@ -1630,12 +1630,12 @@ remunreach(struct p2env *p2e)
 		do {
 			ctree = next;
 			next = DLIST_NEXT(ctree, qelem);
-			
+
 			if (ctree->type == IP_NODE)
 				tfree(ctree->ip_node);
 			DLIST_REMOVE(ctree, qelem);
 		} while (ctree != bb->last);
-			
+
 		DLIST_REMOVE(bb, bbelem);
 		bb = nbb;
 	}
@@ -1697,7 +1697,7 @@ void flownodeprint(NODE *p,FILE *flowdiagramfile);
 
 void
 flownodeprint(NODE *p,FILE *flowdiagramfile)
-{	
+{
 	struct attr *ap;
 	int opty;
 	char *o;
@@ -1705,16 +1705,16 @@ flownodeprint(NODE *p,FILE *flowdiagramfile)
 	fprintf(flowdiagramfile,"{");
 
 	o = opst[p->n_op];
-	
+
 	while (*o != 0) {
 		if (*o == '<' || *o == '>')
 			fputc('\\', flowdiagramfile);
-		
+
 		fputc(*o, flowdiagramfile);
 		o++;
 	}
-	
-	switch( p->n_op ) {			
+
+	switch( p->n_op ) {
 		case REG:
 			fprintf(flowdiagramfile, " %s", rnames[p->n_rval]);
 			break;
@@ -1744,21 +1744,21 @@ flownodeprint(NODE *p,FILE *flowdiagramfile)
 			fprintf(flowdiagramfile, " align=%d", ap->iarg(1));
 			break;
 	}
-	
+
 	opty = optype(p->n_op);
-	
+
 	if (opty != LTYPE) {
 		fprintf(flowdiagramfile, "| {");
-	
+
 		flownodeprint(p->n_left, flowdiagramfile);
-	
+
 		if (opty == BITYPE) {
 			fprintf(flowdiagramfile, "|");
 			flownodeprint(p->n_right, flowdiagramfile);
 		}
 		fprintf(flowdiagramfile, "}");
 	}
-	
+
 	fprintf(flowdiagramfile, "}");
 }
 
@@ -1774,10 +1774,10 @@ printflowdiagram(struct p2env *p2e, char *type) {
 	int filenamesize;
 	char *ext = ".dot";
 	FILE *flowdiagramfile;
-	
+
 	if (!g2debug)
 		return;
-	
+
 	bbb = DLIST_NEXT(&p2e->bblocks, bbelem);
 	ip = bbb->first;
 
@@ -1786,38 +1786,38 @@ printflowdiagram(struct p2env *p2e, char *type) {
 	plg = (struct interpass_prolog *)ip;
 
 	name = plg->ipp_name;
-	
+
 	filenamesize = (int)(strlen(name)+1+strlen(type)+strlen(ext)+1);
 	filename = tmpalloc(filenamesize);
 	snprintf(filename, filenamesize,"%s-%s%s",name,type,ext);
-	
+
 	flowdiagramfile = fopen(filename,"w");
-	
+
 	fprintf(flowdiagramfile, "digraph {\n");
 	fprintf(flowdiagramfile, "rankdir=LR\n");
-	
+
 	DLIST_FOREACH(bbb, &p2e->bblocks, bbelem) {
 		ip = bbb->first;
-		
+
 		fprintf(flowdiagramfile, "bb%p [shape=record ",bbb);
-		
+
 		if (ip->type == IP_PROLOG)
 			fprintf(flowdiagramfile, "root ");
 
 		fprintf(flowdiagramfile, "label=\"");
-		
+
 		SLIST_FOREACH(phi, &bbb->phi, phielem) {
 			fprintf(flowdiagramfile, "Phi %d|", phi->tmpregno);
-		}		
-		
-		
+		}
+
+
 		while (1) {
 			switch (ip->type) {
-				case IP_NODE: 
+				case IP_NODE:
 					flownodeprint(ip->ip_node, flowdiagramfile);
 					break;
 
-				case IP_DEFLAB: 
+				case IP_DEFLAB:
 					fprintf(flowdiagramfile, "Label: %d", ip->ip_lbl);
 					break;
 
@@ -1836,7 +1836,7 @@ printflowdiagram(struct p2env *p2e, char *type) {
 			ip = DLIST_NEXT(ip, qelem);
 		}
 		fprintf(flowdiagramfile, "\"]\n");
-		
+
 		SLIST_FOREACH(cn, &bbb->child, chld) {
 			char *color = "black";
 			struct interpass *pip = bbb->last;
@@ -1892,9 +1892,9 @@ static int is_goto_label(struct interpass*g, struct interpass* l)
 #endif
 
 /*
- * iterate over the basic blocks. 
+ * iterate over the basic blocks.
  * In case a block has only one successor and that one has only one pred, and the link is a goto:
- * place the second one immediately behind the first one (in terms of nodes, means cut&resplice). 
+ * place the second one immediately behind the first one (in terms of nodes, means cut&resplice).
  * This should take care of a lot of jumps.
  * one problem: Cannot move the first or last basic block (prolog/epilog). This is taken care of by
  * moving block #1 to #2, not #2 to #1
@@ -1931,7 +1931,7 @@ static unsigned long map_blocks(struct p2env* p2e, struct block_map* map, unsign
 
 		/* ignore the first 2 labels, maybe up to 3 BBs */
 		if (ignore) {
-			if (bb->first->type == IP_DEFLAB) 
+			if (bb->first->type == IP_DEFLAB)
 				--ignore;
 
 			map[indx].thread = 1 ;	/* these are "fixed" */
@@ -1944,7 +1944,7 @@ static unsigned long map_blocks(struct p2env* p2e, struct block_map* map, unsign
 	thread = 1 ;
 	do {
 		changes = 0 ;
-		
+
 		for (indx=0; indx < count; indx++) {
 			/* find block without trace */
 			if (map[indx].thread == 0) {
@@ -1953,7 +1953,7 @@ static unsigned long map_blocks(struct p2env* p2e, struct block_map* map, unsign
 				struct basicblock *block2 = 0;
 				unsigned long i ;
 				unsigned long added ;
-				
+
 				BDEBUG (("new thread %ld at block %ld\n", thread, indx)) ;
 
 				bb = map[indx].block ;
@@ -1969,8 +1969,8 @@ static unsigned long map_blocks(struct p2env* p2e, struct block_map* map, unsign
 							changes ++ ;
 							added++ ;
 
-							/* 
-							 * pick one from followers. For now (simple), pick the 
+							/*
+							 * pick one from followers. For now (simple), pick the
 							 * one who is directly following us. If none of that exists,
 							 * this code picks the last one.
 							 */
@@ -2156,7 +2156,7 @@ xasmionize(NODE *p, void *arg)
 	if (XASMVAL(cw) == 'n' || XASMVAL(cw) == 'm')
 		return; /* no flow analysis */
 	p = p->n_left;
- 
+
 	if (XASMVAL(cw) == 'g' && p->n_op != TEMP && p->n_op != REG)
 		return; /* no flow analysis */
 
@@ -2172,7 +2172,7 @@ xasmionize(NODE *p, void *arg)
 			BITSET(bb->killed, MKTOFF(b));
 		} else if (p->n_op == REG) {
 			BITCLEAR(bb->gen, b);
-			BITSET(bb->killed, b);	 
+			BITSET(bb->killed, b);
 		} else
 			uerror("bad xasm node type %d", p->n_op);
 	}

--- a/mip/pass2.h
+++ b/mip/pass2.h
@@ -29,7 +29,7 @@
  * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  * HOWEVER CAUSED AND ON ANY THEORY OFLIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <sys/types.h>
@@ -332,8 +332,8 @@ extern	int dope[];	/* a vector containing operator information */
 extern	char *opst[];	/* a vector containing names for ops */
 
 #ifdef PCC_DEBUG
-
-static inline int
+/* Debug versions - static functions for better error checking */
+static int
 optype(int o)
 {
 	if (o >= MAXOP+1)
@@ -341,7 +341,7 @@ optype(int o)
 	return (dope[o]&TYFLG);
 }
 
-static inline int
+static int
 asgop(int o)
 {
 	if (o >= MAXOP+1)
@@ -349,7 +349,7 @@ asgop(int o)
 	return (dope[o]&ASGFLG);
 }
 
-static inline int
+static int
 logop(int o)
 {
 	if (o >= MAXOP+1)
@@ -357,7 +357,7 @@ logop(int o)
 	return (dope[o]&LOGFLG);
 }
 
-static inline int
+static int
 callop(int o)
 {
 	if (o >= MAXOP+1)
@@ -366,9 +366,9 @@ callop(int o)
 }
 
 #else
-
+/* Production versions - macro definitions for performance */
 #define optype(o)	(dope[o]&TYFLG)
-#define asgop(o)	(dope[o]&ASGFLG) 
+#define asgop(o)	(dope[o]&ASGFLG)
 #define logop(o)	(dope[o]&LOGFLG)
 #define callop(o)	(dope[o]&CALLFLG)
 

--- a/os/darwin/ccconfig.h
+++ b/os/darwin/ccconfig.h
@@ -47,9 +47,9 @@
 #if defined(mach_amd64)
 #define AS_ARCH_FLAG		strlist_append(&args, "x86_64");
 #define TARGET_GLOBALS	int amd64_i386;
-#define XCODE_PLATFORM		
+#define XCODE_PLATFORM
 #define XCODE_SELECT_LINK
-#define XCODE_PLATFORM_SDK	
+#define XCODE_PLATFORM_SDK
 #elif defined(mach_aarch64)
 #define AS_ARCH_FLAG		strlist_append(&args, "arm64");
 #define XCODE_PLATFORM		"MacOSX"
@@ -58,13 +58,13 @@
 #elif defined(mach_i386)
 #define AS_ARCH_FLAG		strlist_append(&args, "i386");
 #define TARGET_ASFLAGS
-#define XCODE_PLATFORM		
+#define XCODE_PLATFORM
 #define XCODE_SELECT_LINK
-#define XCODE_PLATFORM_SDK	
+#define XCODE_PLATFORM_SDK
 #endif
 
-#define DEFLIBS		{ "-lSystem", NULL } //"-lpcc", 
-#define DEFPROFLIBS	{ "-lSystem_profile",  NULL } //"-lpcc",
+#define DEFLIBS		{ "-lSystem", NULL } /* "-lpcc", */
+#define DEFPROFLIBS	{ "-lSystem_profile",  NULL } /* "-lpcc", */
 #define DEFLIBDIRS	{ XCODE_PLATFORM_SDK "/usr/lib", NULL }
 #ifndef STDINC
 #define STDINC		XCODE_PLATFORM_SDK "/usr/include"
@@ -82,8 +82,8 @@
 ld -arch ppc -weak_reference_mismatches non-weak -o a.out -lcrt1.o -lcrt2.o -L/usr/lib/gcc/powerpc-apple-darwin8/4.0.1 hello_ppc.o -lgcc -lSystemStubs -lSystem
 */
 
-#define DEFLIBS		{ "-lcrt1.o", "-lcrt2.o", "-lSystem", NULL } //"-lgcc", "-lmx",
-#define DEFPROFLIBS	{ "-lcrt1.o", "-lcrt2.o", "-lSystem_profile", NULL } // "-lgcc", "-lmx", 
+#define DEFLIBS		{ "-lcrt1.o", "-lcrt2.o", "-lSystem", NULL } /* "-lgcc", "-lmx", */
+#define DEFPROFLIBS	{ "-lcrt1.o", "-lcrt2.o", "-lSystem_profile", NULL } /* "-lgcc", "-lmx", */
 #define DEFLIBDIRS	{ "/usr/lib", "/usr/lib/gcc/powerpc-apple-darwin8/4.0.0", NULL }
 #undef PCCLIBDIR
 


### PR DESCRIPTION
   This patch converts all 153 C++ style comments (//) to C89-compatible
   C-style comments (/* */), enabling PCC to build with strict ANSI C flags
   like -ansi, -std=c89, and -std=c90.

   Changes include:
   - Convert all // comments to /* */ in 42 source files
   - Clean up trailing whitespace in affected files
   - Critical fixes in cc/cpp/token.c (lines 1013, 1017) that caused build failures with -ansi flag

   This makes PCC compatible with stricter C standards while maintaining
   all existing functionality. Most changes are debug printf statements
   and disabled code blocks.

   Files modified: 42
   - Architecture-specific: ~23 files
   - Compiler components (ccom, cpp, cxxcom): ~10 files
   - Middle-end and utilities: ~9 files


#40 In PortableCC/pcc;